### PR TITLE
Fixing behavior on short sticks due to SDSL not liking empty vectors.

### DIFF
--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -328,9 +328,12 @@ struct ValueIndex
       }
     }
 
-    sdsl::sd_vector<> temp(buffer.begin(), buffer.end());
-    this->values.swap(temp);
-    sdsl::util::clear(buffer);
+    if(buffer.size() > 0) {
+        // Fills in values, but only works if there are any values to fill
+        sdsl::sd_vector<> temp(buffer.begin(), buffer.end());
+        this->values.swap(temp);
+        sdsl::util::clear(buffer);
+    }
 
     sdsl::util::init_support(this->value_rank, &(this->values));
     sdsl::util::init_support(this->first_select, &(this->first_occ));


### PR DESCRIPTION
This is the issue that was throwing me off with my non-branching "graph" in #2. That now works:

```
[anovak@kolossus gcsa2]$ vg construct -r ../vg/test/small/x.fa > x.vg
[anovak@kolossus gcsa2]$ vg kmers -g -k 8 x.vg >x.gcsa2
[anovak@kolossus gcsa2]$ ./build_gcsa x
GCSA builder

Input: x.gcsa2 (text format)
Doubling steps: 3

GCSA::prefixDoubling(): Initial path length 8
  mergePaths(): 1010 -> 1010 paths
  mergePaths(): 964 unique, 46 unsorted, 0 nondeterministic paths
GCSA::prefixDoubling(): Step 1 (path length 8 -> 16)
  joinPaths(): Reserving space for 1010 paths
  joinPaths(): 1010 -> 1010 paths
  mergePaths(): 1010 -> 1010 paths
  mergePaths(): 1010 unique, 0 unsorted, 0 nondeterministic paths
GCSA::mergeByLabel(): 1010 -> 1010 paths
Index built in 0.00705573 seconds

Paths:            1010
Edges:            1010
Samples:          3 (at 3 positions, 12 bits each)
Max query:        18446744073709551615
Index size:       0.00430584 MB
Without samples:  0.00428963 MB

Index verification complete.

Memory usage: 4.41406 MB

[anovak@kolossus gcsa2]$ 
```
