### PR TITLE
move verifyindex to GCSA itself for easier external use

### DIFF
--- a/gcsa.h
+++ b/gcsa.h
@@ -77,6 +77,9 @@ public:
     size_type doubling_steps = DOUBLING_STEPS, size_type size_limit = SIZE_LIMIT,
     const Alphabet& _alpha = Alphabet());
 
+  // verify
+  void verifyIndex(std::vector<KMer>& kmers, size_type kmer_length);
+
 //------------------------------------------------------------------------------
 
   /*


### PR DESCRIPTION
Moves the verification procedures to the index itself, so that they can be used externally.
