### PR TITLE
use stxxl::vector instead of std::vector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SDSL_DIR=../sdsl-lite
+STXXL_DIR=../stxxl
 
 # In OS X, getrusage() returns maximum resident set size in bytes.
 # In Linux, the value is in kilobytes, so this line should be commented out.
@@ -17,12 +18,12 @@ OUTPUT_FLAGS=-DVERBOSE_STATUS_INFO
 OTHER_FLAGS=$(RUSAGE_FLAGS) $(VERIFY_FLAGS) $(PARALLEL_FLAGS) $(OUTPUT_FLAGS)
 
 include $(SDSL_DIR)/Make.helper
-CXX_FLAGS=$(MY_CXX_FLAGS) $(OTHER_FLAGS) $(MY_CXX_OPT_FLAGS) -I$(INC_DIR)
+CXX_FLAGS=$(MY_CXX_FLAGS) $(OTHER_FLAGS) $(MY_CXX_OPT_FLAGS) -I$(INC_DIR) -I$(STXXL_DIR)/include -I$(STXXL_DIR)/build/include
 LIBOBJS=dbg.o files.o gcsa.o support.o utils.o
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
 OBJS=$(SOURCES:.cpp=.o)
-LIBS=-L$(LIB_DIR) -lsdsl -ldivsufsort -ldivsufsort64
+LIBS=-L$(LIB_DIR) -L$(STXXL_DIR)/build/lib -lsdsl -ldivsufsort -ldivsufsort64 -lstxxl
 LIBRARY=libgcsa2.a
 PROGRAMS=build_gcsa convert_graph
 

--- a/dbg.cpp
+++ b/dbg.cpp
@@ -162,7 +162,7 @@ DeBruijnGraph::load(std::istream& in)
 
 //------------------------------------------------------------------------------
 
-DeBruijnGraph::DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha)
+DeBruijnGraph::DeBruijnGraph(const stxxl::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha)
 {
   this->node_count = keys.size();
   this->graph_order = kmer_length;

--- a/dbg.h
+++ b/dbg.h
@@ -66,7 +66,7 @@ public:
     The input vector must be sorted and contain only unique kmers of length 16 or less.
     Each kmer must have at least one predecessor and one successor.
   */
-  DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha = Alphabet());
+  DeBruijnGraph(const stxxl::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha = Alphabet());
 
 //------------------------------------------------------------------------------
 

--- a/files.cpp
+++ b/files.cpp
@@ -35,7 +35,7 @@ const std::string TEXT_EXTENSION = ".gcsa2";
 //------------------------------------------------------------------------------
 
 bool
-tokenize(const std::string& line, std::vector<std::string>& tokens)
+tokenize(const std::string& line, stxxl::vector<std::string>& tokens)
 {
   {
     std::string token;
@@ -77,7 +77,7 @@ readText(std::istream& in, std::vector<KMer>& kmers, bool append)
     std::getline(in, line);
     if(in.eof()) { break; }
 
-    std::vector<std::string> tokens;
+    stxxl::vector<std::string> tokens;
     if(!tokenize(line, tokens)) { continue; }
     if(kmer_length == ~(size_type)0)
     {

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -218,10 +218,10 @@ GCSA::load(std::istream& in)
 }
 
 //------------------------------------------------------------------------------
-
+/*
 void
 readPathNodes(const std::string& filename,
-  std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels)
+  stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels)
 {
   sdsl::util::clear(paths); sdsl::util::clear(labels);
 
@@ -239,6 +239,7 @@ readPathNodes(const std::string& filename,
   for(size_type i = 0; i < path_count; i++) { paths.push_back(PathNode(in, labels)); }
   in.close(); remove(filename.c_str());
 }
+*/
 
 GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
   size_type doubling_steps, size_type size_limit, const Alphabet& _alpha)
@@ -266,7 +267,7 @@ GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
   }
 
   // Sort the kmers, build the mapper GCSA for generating the edges.
-  std::vector<key_type> keys;
+  stxxl::vector<key_type> keys;
   sdsl::int_vector<0> last_char;
   uniqueKeys(kmers, keys, last_char);
   DeBruijnGraph mapper(keys, kmer_length, _alpha);
@@ -274,37 +275,47 @@ GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
   sdsl::util::clear(keys);
 
   // Transform the kmers into PathNodes.
-  std::vector<PathNode> paths;
-  std::vector<PathNode::rank_type> labels;
+  stxxl::vector<PathNode> paths;
+  stxxl::vector<PathNode::rank_type> labels;
   {
-    std::string temp_file = tempFile(EXTENSION);
-    std::ofstream out(temp_file.c_str(), std::ios_base::binary);
+      //std::string temp_file = tempFile(EXTENSION);
+      //std::ofstream out(temp_file.c_str(), std::ios_base::binary);
+      /*
     if(!out)
     {
       std::cerr << "GCSA::GCSA(): Cannot open temporary file " << temp_file << std::endl;
       std::cerr << "GCSA::GCSA(): Construction aborted" << std::endl;
       std::exit(EXIT_FAILURE);
     }
+      */
 
-    std::vector<PathNode::rank_type> temp_labels = PathNode::dummyRankVector();
-    size_type kmer_count = kmers.size(); sdsl::write_member(kmer_count, out);
-    size_type rank_count = 2 * kmer_count; sdsl::write_member(rank_count, out);
+    stxxl::vector<PathNode::rank_type> temp_labels = PathNode::dummyRankVector();
+    size_type kmer_count = kmers.size();
+    size_type rank_count = 2 * kmer_count;
     for(size_type i = 0; i < kmers.size(); i++)
     {
       PathNode temp(kmers[i], temp_labels);
-      temp.serialize(out, temp_labels);
+      temp.setPointer(labels.size());
+      paths.push_back(temp);
+      for (auto& range : temp_labels) {
+          labels.push_back(range);
+      }
+      //temp.serialize(out, temp_labels);
       temp_labels.resize(0);
     }
-    out.close();
+    //out.close();
 
     sdsl::util::clear(kmers);
-    readPathNodes(temp_file, paths, labels);
+    //readPathNodes(temp_file, paths, labels);
+    //labels.reserve(rank_count + 4);
   }
+  //std::cerr << "before prefix doublin with " << paths.size() << " " << labels.size() << std::endl;
+  //for (auto& path : paths) { path.print(std::cerr, labels); std::cerr << std::endl; }
 
   // Build the GCSA in PathNodes.
   this->prefixDoubling(paths, labels, kmer_length, doubling_steps, size_limit, lcp);
   sdsl::util::clear(lcp);
-  std::vector<range_type> from_nodes;
+  stxxl::vector<range_type> from_nodes;
   this->mergeByLabel(paths, labels, from_nodes);
 
   this->build(paths, labels, mapper, last_char);
@@ -314,7 +325,7 @@ GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
 //------------------------------------------------------------------------------
 
 std::ostream&
-printOccs(const std::vector<node_type>& occs, std::ostream& out)
+printOccs(const stxxl::vector<node_type>& occs, std::ostream& out)
 {
   out << "{";
   for(size_type i = 0; i < occs.size(); i++)
@@ -327,7 +338,7 @@ printOccs(const std::vector<node_type>& occs, std::ostream& out)
 
 void
 printFailure(const std::string& kmer,
-             const std::vector<node_type>& expected, const std::vector<node_type>& occs)
+             const stxxl::vector<node_type>& expected, const stxxl::vector<node_type>& occs)
 {
   std::cerr << "GCSA::verifyIndex(): locate(" << kmer << ") failed" << std::endl;
   std::cerr << "GCSA::verifyIndex(): Expected ";
@@ -380,10 +391,10 @@ GCSA::verifyIndex(std::vector<KMer>& kmers, size_type kmer_length) const
         i = next; continue;
       }
 
-      std::vector<node_type> expected;
+      stxxl::vector<node_type> expected;
       for(size_type j = i; j < next; j++) { expected.push_back(kmers[j].from); }
       removeDuplicates(expected, false);
-      std::vector<node_type> occs;
+      stxxl::vector<node_type> occs;
       this->locate(range, occs);
 
       if(occs.size() != expected.size())
@@ -455,9 +466,9 @@ struct ValueIndex
   sdsl::bit_vector                first_occ;  // Marks the first occurrence of each rank.
   sdsl::bit_vector::select_1_type first_select;
 
-  ValueIndex(const std::vector<ValueType>& input)
+  ValueIndex(const stxxl::vector<ValueType>& input)
   {
-    std::vector<size_type> buffer;
+    stxxl::vector<size_type> buffer;
     this->first_occ = sdsl::bit_vector(input.size(), 0);
 
     size_type prev = ~(size_type)0;
@@ -507,7 +518,7 @@ getTails(const std::vector<range_type>& bounds)
 }
 
 void
-removeGaps(std::vector<PathNode>& paths, const std::vector<range_type>& bounds, std::vector<size_type>& tail)
+removeGaps(stxxl::vector<PathNode>& paths, const std::vector<range_type>& bounds, std::vector<size_type>& tail)
 {
   for(size_type thread = 1; thread < bounds.size(); thread++)
   {
@@ -528,9 +539,9 @@ sumOf(const std::vector<size_type>& statistics)
 }
 
 //------------------------------------------------------------------------------
-
+/*
 void
-writePaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+writePaths(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   std::ostream& out, size_type size_limit,
   size_type& new_path_count, size_type& new_rank_count)
 {
@@ -548,12 +559,13 @@ writePaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& label
   }
   paths.clear(); labels.clear();
 }
+*/
 
 /*
   Join paths by left.to == right.from. Pre-/postcondition: paths are sorted by labels.
 */
 void
-joinPaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels, size_type size_limit)
+joinPaths(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels, size_type size_limit)
 {
   // Initialization.
   PathFromComparator from_c; // Sort the paths by from.
@@ -563,6 +575,7 @@ joinPaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels
   size_type threads = omp_get_max_threads();
 
   // Create a temporary file.
+  /*
   std::string temp_file = tempFile(GCSA::EXTENSION);
   std::ofstream out(temp_file.c_str(), std::ios_base::binary);
   if(!out)
@@ -571,12 +584,12 @@ joinPaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels
               << ", construction aborted" << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  size_type new_path_count = 0, new_rank_count = 0;
-  sdsl::write_member(new_path_count, out); sdsl::write_member(new_rank_count, out);
+  */
+  //sdsl::write_member(new_path_count, out); sdsl::write_member(new_rank_count, out);
 
   // Create the next generation.
-  std::vector<PathNode> temp_nodes[threads];
-  std::vector<PathNode::rank_type> temp_labels[threads];
+  stxxl::vector<PathNode> temp_nodes[threads];
+  stxxl::vector<PathNode::rank_type> temp_labels[threads];
   #pragma omp parallel for schedule(static)
   for(size_type i = 0; i < paths.size(); i++)
   {
@@ -593,23 +606,46 @@ joinPaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels
         temp_nodes[thread].push_back(PathNode(paths[i], paths[j], labels, temp_labels[thread]));
       }
     }
+    /*
     if(temp_nodes[thread].size() >= GCSA::WRITE_BUFFER_SIZE)
     {
       writePaths(temp_nodes[thread], temp_labels[thread], out, size_limit, new_path_count, new_rank_count);
     }
+    */
   }
+  
+  size_type new_path_count = 0, new_rank_count = 0;
+  for(size_type thread = 0; thread < threads; thread++) {
+    new_path_count += temp_nodes[thread].size();
+    new_rank_count += temp_labels[thread].size();
+  }
+
+  // now drop the results into our next iteration
+  paths.clear(); paths.reserve(new_path_count+4);
+  labels.clear(); labels.reserve(new_rank_count+4);
+  
   for(size_type thread = 0; thread < threads; thread++)
   {
-    writePaths(temp_nodes[thread], temp_labels[thread], out, size_limit, new_path_count, new_rank_count);
+    for (auto& path_node : temp_nodes[thread]) {
+      paths.push_back(path_node);
+    }
+    for (auto& label : temp_labels[thread]) {
+      labels.push_back(label);
+    }
+    //writePaths(temp_nodes[thread], temp_labels[thread], out, size_limit, new_path_count, new_rank_count);
   }
 
   // Write the path/rank counts.
+  /*
   out.seekp(0);
   sdsl::write_member(new_path_count, out); sdsl::write_member(new_rank_count, out);
   out.close();
+  */
 
   // Replace the current generation with the next generation.
-  readPathNodes(temp_file, paths, labels);
+  //readPathNodes(temp_file, paths, labels);
+  //labels.clear();
+  
 #ifdef VERBOSE_STATUS_INFO
   std::cerr << "  joinPaths(): " << old_path_count << " -> " << paths.size() << " paths ("
             << labels.size() << " ranks)" << std::endl;
@@ -627,29 +663,28 @@ joinPaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels
   the beginning, while range.first > bounds.second means the end.
 */
 range_type
-nextRange(range_type range, const std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+nextRange(range_type range, const stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   range_type bounds)
 {
-  if(Range::empty(range)) { range.first = bounds.first; range.second = bounds.first; }
+  if(Range::empty(range)) {
+      range.first = bounds.first; range.second = bounds.first; }
   else { range.first = range.second = range.second + 1; }
-
   PathFirstComparator pfc(labels);
   while(range.second + 1 <= bounds.second && !pfc(paths[range.first], paths[range.second + 1]))
   {
     range.second++;
   }
-
   return range;
 }
 
 range_type
-firstRange(const std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels, range_type bounds)
+firstRange(const stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels, range_type bounds)
 {
   return nextRange(range_type(1, 0), paths, labels, bounds);
 }
 
 inline bool
-sameFrom(range_type range, const std::vector<PathNode>& paths)
+sameFrom(range_type range, const stxxl::vector<PathNode>& paths)
 {
   for(size_type i = range.first + 1; i <= range.second; i++)
   {
@@ -668,9 +703,9 @@ sameFrom(range_type range, const std::vector<PathNode>& paths)
 */
 struct SafeSplitComparator
 {
-  const std::vector<PathNode::rank_type>& labels;
+  const stxxl::vector<PathNode::rank_type>& labels;
 
-  explicit SafeSplitComparator(const std::vector<PathNode::rank_type>& _labels) : labels(_labels) { }
+  explicit SafeSplitComparator(const stxxl::vector<PathNode::rank_type>& _labels) : labels(_labels) { }
 
   inline bool operator() (const PathNode& left, const PathNode& right) const
   {
@@ -689,7 +724,7 @@ struct SafeSplitComparator
   However, the last PathNode in a range never gets overwritten, so this should be safe.
 */
 range_type
-extendRange(range_type& range, const std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+extendRange(range_type& range, const stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   const LCP& lcp, range_type bounds)
 {
   range_type min_lcp(0, 0);
@@ -726,7 +761,7 @@ extendRange(range_type& range, const std::vector<PathNode>& paths, std::vector<P
   Merges the path nodes into paths[range.first].
 */
 void
-mergePathNodes(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+mergePathNodes(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   range_type range, range_type range_lcp, const LCP& lcp)
 {
   if(Range::length(range) == 1)
@@ -763,7 +798,7 @@ mergePathNodes(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& l
   entire path can be marked sorted, even though its label is non-unique.
 */
 size_type
-mergePaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels, const LCP& lcp)
+mergePaths(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels, const LCP& lcp)
 {
   size_type old_path_count = paths.size();
 
@@ -817,7 +852,7 @@ mergePaths(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& label
 //------------------------------------------------------------------------------
 
 void
-GCSA::prefixDoubling(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+GCSA::prefixDoubling(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   size_type kmer_length, size_type doubling_steps, size_type size_limit,
   const LCP& lcp)
 {
@@ -845,7 +880,7 @@ GCSA::prefixDoubling(std::vector<PathNode>& paths, std::vector<PathNode::rank_ty
   This version assumes that the paths have identical labels.
 */
 void
-mergePathNodes(std::vector<PathNode>& paths, range_type range)
+mergePathNodes(stxxl::vector<PathNode>& paths, range_type range)
 {
   paths[range.first].makeSorted();
   for(size_type i = range.first + 1; i <= range.second; i++)
@@ -855,8 +890,8 @@ mergePathNodes(std::vector<PathNode>& paths, range_type range)
 }
 
 void
-GCSA::mergeByLabel(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
-  std::vector<range_type>& from_nodes)
+GCSA::mergeByLabel(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
+  stxxl::vector<range_type>& from_nodes)
 {
   sdsl::util::clear(from_nodes);
   size_type old_path_count = paths.size();
@@ -910,7 +945,7 @@ GCSA::mergeByLabel(std::vector<PathNode>& paths, std::vector<PathNode::rank_type
 //------------------------------------------------------------------------------
 
 std::pair<PathLabel, PathLabel>
-predecessor(const PathNode& curr, std::vector<PathNode::rank_type>& labels,
+predecessor(const PathNode& curr, stxxl::vector<PathNode::rank_type>& labels,
   comp_type comp, const DeBruijnGraph& mapper, const sdsl::int_vector<0>& last_char)
 {
   size_type i = 0, j = curr.pointer();
@@ -953,7 +988,7 @@ predecessor(const PathNode& curr, std::vector<PathNode::rank_type>& labels,
   FIXME Later: parallelize
 */
 void
-GCSA::build(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+GCSA::build(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
   DeBruijnGraph& mapper, sdsl::int_vector<0>& last_char)
 {
   for(size_type i = 0; i < paths.size(); i++) { paths[i].initDegree(); }
@@ -1045,11 +1080,11 @@ GCSA::initSupport()
 
 //------------------------------------------------------------------------------
 
-std::vector<node_type>
-fromNodes(size_type path, const std::vector<PathNode>& paths,
-  size_type& additional, const std::vector<range_type>& from_nodes)
+stxxl::vector<node_type>
+fromNodes(size_type path, const stxxl::vector<PathNode>& paths,
+  size_type& additional, const stxxl::vector<range_type>& from_nodes)
 {
-  std::vector<node_type> res;
+  stxxl::vector<node_type> res;
   res.push_back(paths[path].from);
 
   while(additional < from_nodes.size() && from_nodes[additional].first < path) { additional++; }
@@ -1063,18 +1098,18 @@ fromNodes(size_type path, const std::vector<PathNode>& paths,
 }
 
 void
-GCSA::sample(std::vector<PathNode>& paths, std::vector<range_type>& from_nodes)
+GCSA::sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nodes)
 {
   this->sampled_paths = bit_vector(paths.size(), 0);
   this->samples = bit_vector(paths.size() + from_nodes.size(), 0);
 
   size_type sample_bits = 0;
-  std::vector<node_type> sample_buffer;
+  stxxl::vector<node_type> sample_buffer;
   ValueIndex<range_type, FirstGetter> from_index(from_nodes);
   for(size_type i = 0, j = 0; i < paths.size(); i++)
   {
     bool sample_this = false;
-    std::vector<node_type> curr = fromNodes(i, paths, j, from_nodes);
+    stxxl::vector<node_type> curr = fromNodes(i, paths, j, from_nodes);
     if(paths[i].indegree() > 1) { sample_this = true; }
     if(paths[i].hasPredecessor(ENDMARKER_COMP)) { sample_this = true; }
     for(size_type k = 0; k < curr.size(); k++)
@@ -1086,7 +1121,7 @@ GCSA::sample(std::vector<PathNode>& paths, std::vector<range_type>& from_nodes)
     {
       size_type pred = this->LF(i);
       size_type temp = from_index.find(pred);
-      std::vector<node_type> prev = fromNodes(pred, paths, temp, from_nodes);
+      stxxl::vector<node_type> prev = fromNodes(pred, paths, temp, from_nodes);
       if(prev.size() != curr.size()) { sample_this = true; }
       else
       {
@@ -1127,7 +1162,7 @@ GCSA::sample(std::vector<PathNode>& paths, std::vector<range_type>& from_nodes)
 //------------------------------------------------------------------------------
 
 void
-GCSA::locate(size_type path_node, std::vector<node_type>& results, bool append, bool sort) const
+GCSA::locate(size_type path_node, stxxl::vector<node_type>& results, bool append, bool sort) const
 {
   if(!append) { sdsl::util::clear(results); }
   if(path_node >= this->size())
@@ -1141,7 +1176,7 @@ GCSA::locate(size_type path_node, std::vector<node_type>& results, bool append, 
 }
 
 void
-GCSA::locate(range_type range, std::vector<node_type>& results, bool append, bool sort) const
+GCSA::locate(range_type range, stxxl::vector<node_type>& results, bool append, bool sort) const
 {
   if(!append) { sdsl::util::clear(results); }
   if(Range::empty(range) || range.second >= this->size())
@@ -1158,7 +1193,7 @@ GCSA::locate(range_type range, std::vector<node_type>& results, bool append, boo
 }
 
 void
-GCSA::locateInternal(size_type path_node, std::vector<node_type>& results) const
+GCSA::locateInternal(size_type path_node, stxxl::vector<node_type>& results) const
 {
   size_type steps = 0;
   while(this->sampled_paths[path_node] == 0)

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -628,11 +628,13 @@ joinPaths(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& la
   for(size_type thread = 0; thread < threads; thread++)
   {
     for (auto& path_node : temp_nodes[thread]) {
-      paths.push_back(path_node);
+      paths.push_back(PathNode(path_node, temp_labels[thread], labels));
     }
+    /*
     for (auto& label : temp_labels[thread]) {
       labels.push_back(label);
     }
+    */
     //writePaths(temp_nodes[thread], temp_labels[thread], out, size_limit, new_path_count, new_rank_count);
   }
 

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -290,8 +290,8 @@ GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
       */
 
     stxxl::vector<PathNode::rank_type> temp_labels = PathNode::dummyRankVector();
-    size_type kmer_count = kmers.size();
-    size_type rank_count = 2 * kmer_count;
+    //size_type kmer_count = kmers.size();
+    //size_type rank_count = 2 * kmer_count;
     for(size_type i = 0; i < kmers.size(); i++)
     {
       PathNode temp(kmers[i], temp_labels);
@@ -325,7 +325,7 @@ GCSA::GCSA(std::vector<KMer>& kmers, size_type kmer_length,
 //------------------------------------------------------------------------------
 
 std::ostream&
-printOccs(const stxxl::vector<node_type>& occs, std::ostream& out)
+printOccs(const std::vector<node_type>& occs, std::ostream& out)
 {
   out << "{";
   for(size_type i = 0; i < occs.size(); i++)
@@ -338,7 +338,7 @@ printOccs(const stxxl::vector<node_type>& occs, std::ostream& out)
 
 void
 printFailure(const std::string& kmer,
-             const stxxl::vector<node_type>& expected, const stxxl::vector<node_type>& occs)
+             const std::vector<node_type>& expected, const std::vector<node_type>& occs)
 {
   std::cerr << "GCSA::verifyIndex(): locate(" << kmer << ") failed" << std::endl;
   std::cerr << "GCSA::verifyIndex(): Expected ";
@@ -391,10 +391,10 @@ GCSA::verifyIndex(std::vector<KMer>& kmers, size_type kmer_length) const
         i = next; continue;
       }
 
-      stxxl::vector<node_type> expected;
+      std::vector<node_type> expected;
       for(size_type j = i; j < next; j++) { expected.push_back(kmers[j].from); }
       removeDuplicates(expected, false);
-      stxxl::vector<node_type> occs;
+      std::vector<node_type> occs;
       this->locate(range, occs);
 
       if(occs.size() != expected.size())
@@ -596,6 +596,7 @@ joinPaths(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& la
     size_type thread = omp_get_thread_num();
     if(paths[i].sorted())
     {
+        // broken for multithreaded case
       temp_nodes[thread].push_back(PathNode(paths[i], labels, temp_labels[thread]));
     }
     else
@@ -1080,11 +1081,11 @@ GCSA::initSupport()
 
 //------------------------------------------------------------------------------
 
-stxxl::vector<node_type>
+std::vector<node_type>
 fromNodes(size_type path, const stxxl::vector<PathNode>& paths,
   size_type& additional, const stxxl::vector<range_type>& from_nodes)
 {
-  stxxl::vector<node_type> res;
+  std::vector<node_type> res;
   res.push_back(paths[path].from);
 
   while(additional < from_nodes.size() && from_nodes[additional].first < path) { additional++; }
@@ -1104,12 +1105,12 @@ GCSA::sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nod
   this->samples = bit_vector(paths.size() + from_nodes.size(), 0);
 
   size_type sample_bits = 0;
-  stxxl::vector<node_type> sample_buffer;
+  std::vector<node_type> sample_buffer;
   ValueIndex<range_type, FirstGetter> from_index(from_nodes);
   for(size_type i = 0, j = 0; i < paths.size(); i++)
   {
     bool sample_this = false;
-    stxxl::vector<node_type> curr = fromNodes(i, paths, j, from_nodes);
+    std::vector<node_type> curr = fromNodes(i, paths, j, from_nodes);
     if(paths[i].indegree() > 1) { sample_this = true; }
     if(paths[i].hasPredecessor(ENDMARKER_COMP)) { sample_this = true; }
     for(size_type k = 0; k < curr.size(); k++)
@@ -1121,7 +1122,7 @@ GCSA::sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nod
     {
       size_type pred = this->LF(i);
       size_type temp = from_index.find(pred);
-      stxxl::vector<node_type> prev = fromNodes(pred, paths, temp, from_nodes);
+      std::vector<node_type> prev = fromNodes(pred, paths, temp, from_nodes);
       if(prev.size() != curr.size()) { sample_this = true; }
       else
       {
@@ -1162,7 +1163,7 @@ GCSA::sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nod
 //------------------------------------------------------------------------------
 
 void
-GCSA::locate(size_type path_node, stxxl::vector<node_type>& results, bool append, bool sort) const
+GCSA::locate(size_type path_node, std::vector<node_type>& results, bool append, bool sort) const
 {
   if(!append) { sdsl::util::clear(results); }
   if(path_node >= this->size())
@@ -1176,7 +1177,7 @@ GCSA::locate(size_type path_node, stxxl::vector<node_type>& results, bool append
 }
 
 void
-GCSA::locate(range_type range, stxxl::vector<node_type>& results, bool append, bool sort) const
+GCSA::locate(range_type range, std::vector<node_type>& results, bool append, bool sort) const
 {
   if(!append) { sdsl::util::clear(results); }
   if(Range::empty(range) || range.second >= this->size())
@@ -1193,7 +1194,7 @@ GCSA::locate(range_type range, stxxl::vector<node_type>& results, bool append, b
 }
 
 void
-GCSA::locateInternal(size_type path_node, stxxl::vector<node_type>& results) const
+GCSA::locateInternal(size_type path_node, std::vector<node_type>& results) const
 {
   size_type steps = 0;
   while(this->sampled_paths[path_node] == 0)

--- a/gcsa.h
+++ b/gcsa.h
@@ -135,8 +135,8 @@ public:
     return this->find(pattern, pattern + length);
   }
 
-  void locate(size_type path, stxxl::vector<node_type>& results, bool append = false, bool sort = true) const;
-  void locate(range_type range, stxxl::vector<node_type>& results, bool append = false, bool sort = true) const;
+  void locate(size_type path, std::vector<node_type>& results, bool append = false, bool sort = true) const;
+  void locate(range_type range, std::vector<node_type>& results, bool append = false, bool sort = true) const;
 
 //------------------------------------------------------------------------------
 
@@ -257,7 +257,7 @@ private:
   */
   void sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nodes);
 
-  void locateInternal(size_type path, stxxl::vector<node_type>& results) const;
+  void locateInternal(size_type path, std::vector<node_type>& results) const;
 
 //------------------------------------------------------------------------------
 

--- a/gcsa.h
+++ b/gcsa.h
@@ -135,8 +135,8 @@ public:
     return this->find(pattern, pattern + length);
   }
 
-  void locate(size_type path, std::vector<node_type>& results, bool append = false, bool sort = true) const;
-  void locate(range_type range, std::vector<node_type>& results, bool append = false, bool sort = true) const;
+  void locate(size_type path, stxxl::vector<node_type>& results, bool append = false, bool sort = true) const;
+  void locate(range_type range, stxxl::vector<node_type>& results, bool append = false, bool sort = true) const;
 
 //------------------------------------------------------------------------------
 
@@ -225,21 +225,21 @@ private:
     Increases path length to up to 2^doubling_steps times the original. Sets
     max_query_length. Pre-/postcondition: paths are sorted by labels.
   */
-  void prefixDoubling(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+  void prefixDoubling(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
     size_type kmer_length, size_type doubling_steps, size_type size_limit, const LCP& lcp);
 
   /*
     Merges path nodes having the same labels. Writes the additional from nodes to the given
     vector as pairs (path rank, node). Sets path_node_count.
   */
-  void mergeByLabel(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
-    std::vector<range_type>& from_nodes);
+  void mergeByLabel(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
+    stxxl::vector<range_type>& from_nodes);
 
   /*
     Store the number of outgoing edges in the to fields of each node. Then build the GCSA,
     apart from the fields related to samples. Clears last_labels, mapper, and last_char.
   */
-  void build(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels,
+  void build(stxxl::vector<PathNode>& paths, stxxl::vector<PathNode::rank_type>& labels,
     DeBruijnGraph& mapper, sdsl::int_vector<0>& last_char);
 
   void initSupport();
@@ -255,9 +255,9 @@ private:
     FIXME Later: An alternate sampling scheme for graphs where nodes are not (id, offset)
     pairs.
   */
-  void sample(std::vector<PathNode>& paths, std::vector<range_type>& from_nodes);
+  void sample(stxxl::vector<PathNode>& paths, stxxl::vector<range_type>& from_nodes);
 
-  void locateInternal(size_type path, std::vector<node_type>& results) const;
+  void locateInternal(size_type path, stxxl::vector<node_type>& results) const;
 
 //------------------------------------------------------------------------------
 

--- a/support.cpp
+++ b/support.cpp
@@ -348,17 +348,21 @@ PathNode::PathNode(const PathNode& left, const PathNode& right,
   }
 }
 
-/*
-PathNode::PathNode(std::ifstream& in, stxxl::vector<PathNode::rank_type>& labels)
+PathNode::PathNode(PathNode& source,
+                   stxxl::vector<PathNode::rank_type>& source_labels,
+                   stxxl::vector<PathNode::rank_type>& dest_labels)
 {
-  in.read((char*)this, sizeof(*this));
-  this->setPointer(labels.size());
-
-  rank_type buffer[LABEL_LENGTH + 1];
-  in.read((char*)buffer, this->ranks() * sizeof(rank_type));
-  labels.insert(labels.end(), buffer, buffer + this->ranks());
+  this->copy(source);
+  this->setPointer(dest_labels.size());
+  for (size_type i = 0; i < source.ranks(); ++i) {
+      dest_labels.push_back(source_labels[source.pointer()+i]);
+  }
+  //rank_type buffer[LABEL_LENGTH + 1];
+  //in.read((char*)buffer, this->ranks() * sizeof(rank_type));
+  //labels.insert(labels.end(), buffer, buffer + this->ranks());
 }
 
+/*
 size_type
 PathNode::serialize(std::ostream& out, const stxxl::vector<rank_type>& labels) const
 {

--- a/support.cpp
+++ b/support.cpp
@@ -221,7 +221,7 @@ KMer::KMer()
 {
 }
 
-KMer::KMer(const std::vector<std::string>& tokens, const Alphabet& alpha, size_type successor)
+KMer::KMer(const stxxl::vector<std::string>& tokens, const Alphabet& alpha, size_type successor)
 {
   byte_type predecessors = chars(tokens[2], alpha);
   byte_type successors = chars(tokens[3], alpha);
@@ -250,7 +250,7 @@ operator<< (std::ostream& out, const KMer& kmer)
 }
 
 void
-uniqueKeys(std::vector<KMer>& kmers, std::vector<key_type>& keys, sdsl::int_vector<0>& last_char, bool print)
+uniqueKeys(std::vector<KMer>& kmers, stxxl::vector<key_type>& keys, sdsl::int_vector<0>& last_char, bool print)
 {
   if(kmers.empty()) { return; }
   parallelQuickSort(kmers.begin(), kmers.end());
@@ -268,7 +268,8 @@ uniqueKeys(std::vector<KMer>& kmers, std::vector<key_type>& keys, sdsl::int_vect
 
   // Pass 2: Create the merged key array and the last character array for edge generation.
   // Replace the kmer values with ranks in the key array.
-  keys = std::vector<key_type>(total_keys, 0);
+  //keys = stxxl::vector<key_type>(total_keys, 0);
+  keys.clear(); keys.resize(total_keys);
   last_char = sdsl::int_vector<0>(total_keys, 0, Key::CHAR_WIDTH);
   keys[0] = kmers[0].key; last_char[0] = Key::last(kmers[0].key);
   kmers[0].key = Key::replace(kmers[0].key, 0);
@@ -288,15 +289,15 @@ uniqueKeys(std::vector<KMer>& kmers, std::vector<key_type>& keys, sdsl::int_vect
 
 //------------------------------------------------------------------------------
 
-std::vector<PathNode::rank_type>
+stxxl::vector<PathNode::rank_type>
 PathNode::dummyRankVector()
 {
-  std::vector<rank_type> temp;
+  stxxl::vector<rank_type> temp;
   temp.reserve(LABEL_LENGTH + 1);
   return temp;
 }
 
-PathNode::PathNode(const KMer& kmer, std::vector<PathNode::rank_type>& labels)
+PathNode::PathNode(const KMer& kmer, stxxl::vector<PathNode::rank_type>& labels)
 {
   this->from = kmer.from; this->to = kmer.to;
   this->fields = 0;
@@ -311,7 +312,7 @@ PathNode::PathNode(const KMer& kmer, std::vector<PathNode::rank_type>& labels)
 }
 
 PathNode::PathNode(const PathNode& source,
-    const std::vector<PathNode::rank_type>& old_labels, std::vector<PathNode::rank_type>& new_labels)
+    const stxxl::vector<PathNode::rank_type>& old_labels, stxxl::vector<PathNode::rank_type>& new_labels)
 {
   this->from = source.from; this->to = source.to;
   this->fields = source.fields;
@@ -324,7 +325,7 @@ PathNode::PathNode(const PathNode& source,
 }
 
 PathNode::PathNode(const PathNode& left, const PathNode& right,
-    const std::vector<PathNode::rank_type>& old_labels, std::vector<PathNode::rank_type>& new_labels)
+    const stxxl::vector<PathNode::rank_type>& old_labels, stxxl::vector<PathNode::rank_type>& new_labels)
 {
   this->from = left.from; this->to = right.to;
   if(right.sorted()) { this->makeSorted(); }
@@ -347,7 +348,8 @@ PathNode::PathNode(const PathNode& left, const PathNode& right,
   }
 }
 
-PathNode::PathNode(std::ifstream& in, std::vector<PathNode::rank_type>& labels)
+/*
+PathNode::PathNode(std::ifstream& in, stxxl::vector<PathNode::rank_type>& labels)
 {
   in.read((char*)this, sizeof(*this));
   this->setPointer(labels.size());
@@ -358,7 +360,7 @@ PathNode::PathNode(std::ifstream& in, std::vector<PathNode::rank_type>& labels)
 }
 
 size_type
-PathNode::serialize(std::ostream& out, const std::vector<rank_type>& labels) const
+PathNode::serialize(std::ostream& out, const stxxl::vector<rank_type>& labels) const
 {
   size_type bytes = sizeof(*this);
   out.write((char*)this, sizeof(*this));
@@ -369,6 +371,7 @@ PathNode::serialize(std::ostream& out, const std::vector<rank_type>& labels) con
 
   return bytes;
 }
+*/
 
 PathNode::PathNode()
 {
@@ -376,7 +379,7 @@ PathNode::PathNode()
   this->fields = 0;
 }
 
-PathNode::PathNode(std::vector<rank_type>& labels)
+PathNode::PathNode(stxxl::vector<rank_type>& labels)
 {
   this->from = 0; this->to = 0;
   this->fields = 0;
@@ -427,7 +430,7 @@ PathNode::operator= (PathNode&& source)
 }
 
 void
-PathNode::print(std::ostream& out, const std::vector<PathNode::rank_type>& labels) const
+PathNode::print(std::ostream& out, const stxxl::vector<PathNode::rank_type>& labels) const
 {
   out << "(" << Node::decode(this->from) << " -> " << Node::decode(this->to);
   out << "; o" << this->order();
@@ -446,7 +449,7 @@ PathNode::print(std::ostream& out, const std::vector<PathNode::rank_type>& label
 
 bool
 PathNode::intersect(const PathLabel& first, const PathLabel& last,
-  const std::vector<PathNode::rank_type>& labels) const
+  const stxxl::vector<PathNode::rank_type>& labels) const
 {
   PathLabel my_first = this->firstLabel(labels);
 
@@ -462,7 +465,7 @@ PathNode::intersect(const PathLabel& first, const PathLabel& last,
 }
 
 size_type
-PathNode::min_lcp(const PathNode& another, const std::vector<PathNode::rank_type>& labels) const
+PathNode::min_lcp(const PathNode& another, const stxxl::vector<PathNode::rank_type>& labels) const
 {
   size_type ord = std::min(this->order(), another.order());
   for(size_type i = 0; i < ord; i++)
@@ -473,7 +476,7 @@ PathNode::min_lcp(const PathNode& another, const std::vector<PathNode::rank_type
 }
 
 size_type
-PathNode::max_lcp(const PathNode& another, const std::vector<PathNode::rank_type>& labels) const
+PathNode::max_lcp(const PathNode& another, const stxxl::vector<PathNode::rank_type>& labels) const
 {
   size_type ord = std::min(this->order(), another.order());
   for(size_type i = 0; i < ord; i++)
@@ -489,7 +492,7 @@ LCP::LCP()
 {
 }
 
-LCP::LCP(const std::vector<key_type>& keys, size_type _kmer_length)
+LCP::LCP(const stxxl::vector<key_type>& keys, size_type _kmer_length)
 {
   this->kmer_length = _kmer_length;
   this->total_keys = keys.size();
@@ -505,7 +508,7 @@ LCP::LCP(const std::vector<key_type>& keys, size_type _kmer_length)
 }
 
 range_type
-LCP::min_lcp(const PathNode& a, const PathNode& b, const std::vector<LCP::rank_type>& labels) const
+LCP::min_lcp(const PathNode& a, const PathNode& b, const stxxl::vector<LCP::rank_type>& labels) const
 {
   size_type order = std::min(a.order(), b.order());
   range_type lcp(a.min_lcp(b, labels), 0);
@@ -519,7 +522,7 @@ LCP::min_lcp(const PathNode& a, const PathNode& b, const std::vector<LCP::rank_t
 }
 
 range_type
-LCP::max_lcp(const PathNode& a, const PathNode& b, const std::vector<LCP::rank_type>& labels) const
+LCP::max_lcp(const PathNode& a, const PathNode& b, const stxxl::vector<LCP::rank_type>& labels) const
 {
   size_type order = std::min(a.order(), b.order());
   range_type lcp(a.max_lcp(b, labels), 0);

--- a/support.h
+++ b/support.h
@@ -473,6 +473,10 @@ struct PathNode
 
   PathNode& operator= (PathNode&& source);
 
+  PathNode(PathNode& source,
+           stxxl::vector<PathNode::rank_type>& source_labels,
+           stxxl::vector<PathNode::rank_type>& dest_labels);
+
   /*
     These are dangerous, because the nodes will share the same label. Changing one will
     change the other as well.

--- a/support.h
+++ b/support.h
@@ -217,7 +217,7 @@ struct KMer
   node_type from, to;
 
   KMer();
-  KMer(const std::vector<std::string>& tokens, const Alphabet& alpha, size_type successor);
+  KMer(const stxxl::vector<std::string>& tokens, const Alphabet& alpha, size_type successor);
 
   KMer(key_type _key, node_type _from, node_type _to) :
     key(_key), from(_from), to(_to)
@@ -253,7 +253,7 @@ operator< (key_type key, const KMer& kmer)
   3. Stores the last character of each unique kmer label in an array.
   4. Replaces the kmer labels in the keys by their ranks.
 */
-void uniqueKeys(std::vector<KMer>& kmers, std::vector<key_type>& keys, sdsl::int_vector<0>& last_char,
+void uniqueKeys(std::vector<KMer>& kmers, stxxl::vector<key_type>& keys, sdsl::int_vector<0>& last_char,
   bool print = false);
 
 //------------------------------------------------------------------------------
@@ -385,7 +385,7 @@ struct PathNode
 
   inline size_type ranks() const { return this->order() + 1; }
 
-  inline PathLabel firstLabel(const std::vector<rank_type>& labels) const
+  inline PathLabel firstLabel(const stxxl::vector<rank_type>& labels) const
   {
     PathLabel res;
     res.length = this->order();
@@ -397,7 +397,7 @@ struct PathNode
     return res;
   }
 
-  inline PathLabel lastLabel(const std::vector<rank_type>& labels) const
+  inline PathLabel lastLabel(const stxxl::vector<rank_type>& labels) const
   {
     PathLabel res;
 
@@ -417,48 +417,48 @@ struct PathNode
     return res;
   }
 
-  inline rank_type firstLabel(size_type i, const std::vector<rank_type>& labels) const
+  inline rank_type firstLabel(size_type i, const stxxl::vector<rank_type>& labels) const
   {
     return labels[this->pointer() + i];
   }
 
-  inline rank_type lastLabel(size_type i, const std::vector<rank_type>& labels) const
+  inline rank_type lastLabel(size_type i, const stxxl::vector<rank_type>& labels) const
   {
     if(i < this->lcp()) { return labels[this->pointer() + i]; }
     else { return labels[this->pointer() + this->order()]; }
   }
 
   // Do the two path nodes intersect?
-  bool intersect(const PathLabel& first, const PathLabel& last, const std::vector<rank_type>& labels) const;
+  bool intersect(const PathLabel& first, const PathLabel& last, const stxxl::vector<rank_type>& labels) const;
 
   /*
     Computes the length of the minimal/maximal longest common prefix of the kmer rank
     sequences of this and another. another must come after this in lexicographic order,
     and the ranges must not overlap.
   */
-  size_type min_lcp(const PathNode& another, const std::vector<rank_type>& labels) const;
-  size_type max_lcp(const PathNode& another, const std::vector<rank_type>& labels) const;
+  size_type min_lcp(const PathNode& another, const stxxl::vector<rank_type>& labels) const;
+  size_type max_lcp(const PathNode& another, const stxxl::vector<rank_type>& labels) const;
 
 //------------------------------------------------------------------------------
 
-  static std::vector<rank_type> dummyRankVector();
+  static stxxl::vector<rank_type> dummyRankVector();
 
-  PathNode(const KMer& kmer, std::vector<rank_type>& labels);
+  PathNode(const KMer& kmer, stxxl::vector<rank_type>& labels);
 
   PathNode(const PathNode& source,
-    const std::vector<rank_type>& old_labels, std::vector<rank_type>& new_labels);
+    const stxxl::vector<rank_type>& old_labels, stxxl::vector<rank_type>& new_labels);
 
   PathNode(const PathNode& left, const PathNode& right,
-    const std::vector<rank_type>& old_labels, std::vector<rank_type>& new_labels);
+    const stxxl::vector<rank_type>& old_labels, stxxl::vector<rank_type>& new_labels);
 
-  PathNode(std::ifstream& in, std::vector<rank_type>& labels);
+    //PathNode(std::ifstream& in, stxxl::vector<rank_type>& labels);
 
-  size_type serialize(std::ostream& out, const std::vector<rank_type>& labels) const;
+    //size_type serialize(std::ostream& out, const stxxl::vector<rank_type>& labels) const;
 
-  void print(std::ostream& out, const std::vector<rank_type>& labels) const;
+  void print(std::ostream& out, const stxxl::vector<rank_type>& labels) const;
 
   PathNode();
-  explicit PathNode(std::vector<rank_type>& labels);
+  explicit PathNode(stxxl::vector<rank_type>& labels);
   PathNode(PathNode&& source);
   ~PathNode();
 
@@ -485,9 +485,9 @@ struct PathNode
 // Compares the first labels.
 struct PathFirstComparator
 {
-  const std::vector<PathNode::rank_type>& labels;
+  const stxxl::vector<PathNode::rank_type>& labels;
 
-  explicit PathFirstComparator(const std::vector<PathNode::rank_type>& _labels) : labels(_labels) { }
+  explicit PathFirstComparator(const stxxl::vector<PathNode::rank_type>& _labels) : labels(_labels) { }
 
   inline bool operator() (const PathNode& a, const PathNode& b) const
   {
@@ -522,7 +522,7 @@ struct LCP
   rmq_type            lcp_rmq;
 
   LCP();
-  LCP(const std::vector<key_type>& keys, size_type _kmer_length);
+  LCP(const stxxl::vector<key_type>& keys, size_type _kmer_length);
 
   /*
     Computes the minimal/maximal lcp of the path labels corresponding to path nodes a and b.
@@ -532,8 +532,8 @@ struct LCP
 
     FIXME Later: Do not use the rmq if the kmer ranks are close.
   */
-  range_type min_lcp(const PathNode& a, const PathNode& b, const std::vector<rank_type>& labels) const;
-  range_type max_lcp(const PathNode& a, const PathNode& b, const std::vector<rank_type>& labels) const;
+  range_type min_lcp(const PathNode& a, const PathNode& b, const stxxl::vector<rank_type>& labels) const;
+  range_type max_lcp(const PathNode& a, const PathNode& b, const stxxl::vector<rank_type>& labels) const;
 
   // Increments the lcp by 1.
   inline range_type increment(range_type lcp) const

--- a/utils.cpp
+++ b/utils.cpp
@@ -80,7 +80,7 @@ memoryUsage()
 //------------------------------------------------------------------------------
 
 size_type
-readRows(const std::string& filename, std::vector<std::string>& rows, bool skip_empty_rows)
+readRows(const std::string& filename, stxxl::vector<std::string>& rows, bool skip_empty_rows)
 {
   std::ifstream input(filename.c_str(), std::ios_base::binary);
   if(!input)

--- a/utils.h
+++ b/utils.h
@@ -219,7 +219,7 @@ sequentialSort(Iterator first, Iterator last)
 
 template<class Element>
 void
-removeDuplicates(stxxl::vector<Element>& vec, bool parallel)
+removeDuplicates(std::vector<Element>& vec, bool parallel)
 {
   if(parallel) { parallelQuickSort(vec.begin(), vec.end()); }
   else         { sequentialSort(vec.begin(), vec.end()); }


### PR DESCRIPTION
stxxl is disk-backed, so in theory it could allow lower-memory construction without lots of file writing gymnastics. As a test, I replaced most instances of std::vector with stxxl::vectors and removed any temporary file writes. Construction works on small graphs, but is obviously very slow, and gets worse as we move into the BWT construction itself--- perhaps we should copy into memory to speed that up.

This PR is not to merge in its present state. As of this commit, index construction only appears to work in a single-threaded context. I've messed up one of the multithreaded merging steps. I'd like to use this to discuss the change and examine other ways of reducing memory usage.

To test, you'll need to download stxxl and build it in the directory below gcsa2. Then, build with `mkdir build; cd build; cmake .. -DCMAKE_BUILD_TYPE=Release; make`.
