### PR TITLE
Kmer counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build_gcsa
 convert_gcsa
 convert_graph
+count_kmers
 
 .DS_Store
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Genome Research Ltd.
+Copyright (c) 2015, 2016 Genome Research Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ HEADERS=$(wildcard *.h)
 OBJS=$(SOURCES:.cpp=.o)
 LIBS=-L$(LIB_DIR) -lsdsl -ldivsufsort -ldivsufsort64
 LIBRARY=libgcsa2.a
-PROGRAMS=build_gcsa convert_gcsa convert_graph
+PROGRAMS=build_gcsa convert_gcsa convert_graph count_kmers
 
 all: $(LIBRARY) $(PROGRAMS)
 
@@ -41,6 +41,9 @@ convert_gcsa:convert_gcsa.o $(LIBRARY)
 	$(MY_CXX) $(CXX_FLAGS) -o $@ $< $(LIBRARY) $(LIBS)
 
 convert_graph:convert_graph.o $(LIBRARY)
+	$(MY_CXX) $(CXX_FLAGS) -o $@ $< $(LIBRARY) $(LIBS)
+
+count_kmers:count_kmers.o $(LIBRARY)
 	$(MY_CXX) $(CXX_FLAGS) -o $@ $< $(LIBRARY) $(LIBS)
 
 clean:

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -1,0 +1,68 @@
+/*
+  Copyright (c) 2016 Genome Research Ltd.
+
+  Author: Jouni Siren <jouni.siren@iki.fi>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include <string>
+
+#include "gcsa.h"
+
+using namespace gcsa;
+
+//------------------------------------------------------------------------------
+
+int
+main(int argc, char** argv)
+{
+  if(argc < 3)
+  {
+    std::cerr << "usage: count_kmers base_name k" << std::endl;
+    std::cerr << std::endl;
+    std::exit(EXIT_SUCCESS);
+  }
+
+  std::string base_name = argv[1];
+  size_type k = std::stoul(argv[2]);
+  std::cout << "Kmer counter" << std::endl;
+  std::cout << std::endl;
+  std::cout << "Base name:  " << base_name << std::endl;
+  std::cout << "K: " << k << std::endl;
+  std::cout << std::endl;
+
+  GCSA index;
+  std::string gcsa_name = base_name + GCSA::EXTENSION;
+  sdsl::load_from_file(index, gcsa_name);
+  std::cout << "GCSA:       " << index.size() << " paths, order " << index.order() << std::endl;
+
+  double start = readTimer();
+  size_type kmer_count = index.countKMers(k);
+  double seconds = readTimer() - start;
+  std::cout << "Kmers:      " << kmer_count << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "Kmers counted in " << seconds << " seconds (" << (kmer_count / seconds) << " / s)" << std::endl;
+  std::cout << std::endl;
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -45,7 +45,7 @@ main(int argc, char** argv)
   std::cout << "Kmer counter" << std::endl;
   std::cout << std::endl;
   std::cout << "Base name:  " << base_name << std::endl;
-  std::cout << "K: " << k << std::endl;
+  std::cout << "K:          " << k << std::endl;
   std::cout << std::endl;
 
   GCSA index;

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -722,7 +722,7 @@ struct ReverseTrieNode
   size_type  depth;
   bool       ends_at_sink;
 
-  const static size_type SEED_LENGTH = 4; // Create all patterns of that length before parallelizing.
+  const static size_type SEED_LENGTH = 5; // Create all patterns of that length before parallelizing.
 
   ReverseTrieNode() : range(0, 0), depth(0), ends_at_sink(false) {}
   ReverseTrieNode(range_type rng, size_type d, bool sink) : range(rng), depth(d), ends_at_sink(sink) {}
@@ -784,12 +784,12 @@ GCSA::countKMers(size_type k, bool force) const
     if(force)
     {
       std::cerr << "GCSA::countKMers(): Warning: The value of k (" << k
-                << ") is greater than the order of the grap (" << this->order() << ")" << std::endl;
+                << ") is greater than the order of the graph (" << this->order() << ")" << std::endl;
     }
     else
     {
       std::cerr << "GCSA::countKMers(): The value of k (" << k
-                << ") is greater than the order of the grap (" << this->order() << ")" << std::endl;
+                << ") is greater than the order of the graph (" << this->order() << ")" << std::endl;
       return 0;
     }
   }

--- a/gcsa.h
+++ b/gcsa.h
@@ -73,7 +73,9 @@ public:
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 
-  const static std::string EXTENSION;       // .gcsa
+  const static std::string EXTENSION;     // .gcsa
+
+  const static size_type SHORT_RANGE = 5; // Different strategy for LF(range).
 
 //------------------------------------------------------------------------------
 
@@ -197,15 +199,7 @@ public:
   }
 
   // LF(range, c) for 1 <= c < sigma - 1.
-  inline void LF(range_type range, std::vector<range_type>& results) const
-  {
-    range = this->bwtRange(range);
-    for(size_type comp = 1; comp  + 1 < this->alpha.sigma; comp++)
-    {
-      results[comp] = gcsa::LF(this->bwt, this->alpha, range, comp);
-      if(!Range::empty(results[comp])) { results[comp] = this->pathNodeRange(results[comp]); }
-    }
-  }
+  void LF(range_type range, std::vector<range_type>& results) const;
 
   inline bool sampled(size_type path_node) const { return this->sampled_paths[path_node]; }
 


### PR DESCRIPTION
Count the number of kmers in the index. This is mostly useful for measuring the compression achieved by pruning the de Bruijn graph. The low-level code can serve as a basis for comparing the kmer sets in two indexes.
