### PR TITLE
Suffix tree functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OTHER_FLAGS=$(RUSAGE_FLAGS) $(VERIFY_FLAGS) $(PARALLEL_FLAGS) $(OUTPUT_FLAGS)
 
 include $(SDSL_DIR)/Make.helper
 CXX_FLAGS=$(MY_CXX_FLAGS) $(OTHER_FLAGS) $(MY_CXX_OPT_FLAGS) -I$(INC_DIR)
-LIBOBJS=algorithms.o dbg.o files.o gcsa.o internal.o path_graph.o support.o utils.o
+LIBOBJS=algorithms.o dbg.o files.o gcsa.o internal.o lcp.o path_graph.o support.o utils.o
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
 OBJS=$(SOURCES:.cpp=.o)

--- a/algorithms.h
+++ b/algorithms.h
@@ -42,14 +42,16 @@ namespace gcsa
   the list of occurrences is expected to be the same as the set of start nodes of the
   kmers with that label. To guarantee this, the input should be the same as for the
   constructor, or a subset where all kmers with a given label are either present or
-  absent.
+  absent. Counting queries are also verified.
+
+  If lcp != 0, parent() queries are also verified.
 
   Note: Verification sorts the kmer array.
 
   Returns false if index verification fails, and true otherwise.
 */
-bool verifyIndex(const GCSA& index, std::vector<KMer>& kmers, size_type kmer_length);
-bool verifyIndex(const GCSA& index, const InputGraph& graph);
+bool verifyIndex(const GCSA& index, const LCPArray* lcp, std::vector<KMer>& kmers, size_type kmer_length);
+bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph);
 
 /*
   Kmer counting. Returns the number of kmers of the given length. If k > order(),

--- a/algorithms.h
+++ b/algorithms.h
@@ -26,6 +26,7 @@
 #define _GCSA_ALGORITHMS_H
 
 #include "gcsa.h"
+#include "lcp.h"
 
 namespace gcsa
 {

--- a/build_gcsa.cpp
+++ b/build_gcsa.cpp
@@ -182,7 +182,7 @@ main(int argc, char** argv)
   printHeader("LCP size"); std::cout << inMegabytes(lcp_bytes) << " MB" << std::endl;
   std::cout << std::endl;
 
-  if(verify) { verifyIndex(index, graph); }
+  if(verify) { verifyIndex(index, &lcp, graph); }
 
   std::cout << "Final memory usage: " << inGigabytes(memoryUsage()) << " GB" << std::endl;
   std::cout << std::endl;

--- a/build_gcsa.cpp
+++ b/build_gcsa.cpp
@@ -54,6 +54,8 @@ void verifyMapper(const InputGraph& graph);
 
 //------------------------------------------------------------------------------
 
+const size_type INDENT = 20;
+
 int
 main(int argc, char** argv)
 {
@@ -61,6 +63,7 @@ main(int argc, char** argv)
   {
     std::cerr << "Usage: build_gcsa [options] base_name [base_name2 ..]" << std::endl;
     std::cerr << "  -b    Read the input in binary format (default)" << std::endl;
+    std::cerr << "  -B N  Set LCP branching factor to N (default " << ConstructionParameters::LCP_BRANCHING << ")" << std::endl;
     std::cerr << "  -d N  Doubling steps (default and max " << ConstructionParameters::DOUBLING_STEPS << ")" << std::endl;
     std::cerr << "  -D X  Use X as the directory for temporary files (default: " << TempFile::DEFAULT_TEMP_DIR << ")" << std::endl;
     std::cerr << "  -l N  Limit the size of the graph to N gigabytes (default " << ConstructionParameters::SIZE_LIMIT << ")" << std::endl;
@@ -74,14 +77,16 @@ main(int argc, char** argv)
 
   int c = 0;
   bool binary = true, verify = false;
-  std::string output_file;
+  std::string index_file, lcp_file;
   ConstructionParameters parameters;
-  while((c = getopt(argc, argv, "bd:D:l:o:tT:v")) != -1)
+  while((c = getopt(argc, argv, "bB:d:D:l:o:tT:v")) != -1)
   {
     switch(c)
     {
     case 'b':
       binary = true; break;
+    case 'B':
+      parameters.setLCPBranching(std::stoul(optarg)); break;
     case 'd':
       parameters.setSteps(std::stoul(optarg)); break;
     case 'D':
@@ -89,7 +94,9 @@ main(int argc, char** argv)
     case 'l':
       parameters.setLimit(std::stoul(optarg)); break;
     case 'o':
-      output_file = std::string(optarg) + GCSA::EXTENSION; break;
+      index_file = std::string(optarg) + GCSA::EXTENSION;
+      lcp_file = std::string(optarg) + LCPArray::EXTENSION;
+      break;
     case 't':
       binary = false; break;
     case 'T':
@@ -107,24 +114,27 @@ main(int argc, char** argv)
     std::cerr << "build_gcsa: No input files specified" << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  if(output_file.empty())
+  if(index_file.empty())
   {
-    output_file = std::string(argv[optind]) + GCSA::EXTENSION;
+    index_file = std::string(argv[optind]) + GCSA::EXTENSION;
+    lcp_file = std::string(argv[optind]) + LCPArray::EXTENSION;
   }
 
   std::cout << "GCSA builder" << std::endl;
   std::cout << std::endl;
   for(int i = optind; i < argc; i++)
   {
-    std::cout << "Input:           " << argv[i];
+    printHeader("Input", INDENT);
+    std::cout << argv[i];
     if(binary) { std::cout << InputGraph::BINARY_EXTENSION << " (binary format)" << std::endl; }
     else { std::cout << InputGraph::TEXT_EXTENSION << " (text format)" << std::endl; }
   }
-  std::cout << "Output:          " << output_file << std::endl;
-  std::cout << "Doubling steps:  " << parameters.doubling_steps << std::endl;
-  std::cout << "Size limit:      " << inGigabytes(parameters.size_limit) << " GB" << std::endl;
-  std::cout << "Threads:         " << omp_get_max_threads() << std::endl;
-  std::cout << "Temp directory:  " << TempFile::temp_dir << std::endl;
+  printHeader("Output", INDENT); std::cout << index_file << ", " << lcp_file << std::endl;
+  printHeader("Doubling steps", INDENT); std::cout << parameters.doubling_steps << std::endl;
+  printHeader("Size limit", INDENT); std::cout << inGigabytes(parameters.size_limit) << " GB" << std::endl;
+  printHeader("Branching factor", INDENT); std::cout << parameters.lcp_branching << std::endl;
+  printHeader("Threads", INDENT); std::cout << omp_get_max_threads() << std::endl;
+  printHeader("Temp directory", INDENT); std::cout << TempFile::temp_dir << std::endl;
   std::cout << std::endl;
 
   InputGraph graph(argc - optind, argv + optind, binary);
@@ -138,19 +148,22 @@ main(int argc, char** argv)
 #endif
 
   GCSA index;
+  LCPArray lcp;
 #ifdef LOAD_INDEX
-  sdsl::load_from_file(index, output_file);
+  sdsl::load_from_file(index, index_file);
 #else
   {
     double start = readTimer();
-    GCSA temp(graph, parameters); index.swap(temp);
+    index = GCSA(graph, parameters);
+    lcp = LCPArray(graph, parameters);
     double seconds = readTimer() - start;
     std::cout << "Index built in " << seconds << " seconds" << std::endl;
     std::cout << "Memory usage: " << inGigabytes(memoryUsage()) << " GB" << std::endl;
     std::cout << "I/O volume: " << inGigabytes(readVolume()) << " GB read, "
               << inGigabytes(writeVolume()) << " GB write" << std::endl;
     std::cout << std::endl;
-    sdsl::store_to_file(index, output_file);
+    sdsl::store_to_file(index, index_file);
+    sdsl::store_to_file(lcp, lcp_file);
   }
 #endif
 
@@ -163,8 +176,10 @@ main(int argc, char** argv)
 
   size_type index_bytes = sdsl::size_in_bytes(index);
   size_type sample_bytes = sdsl::size_in_bytes(index.stored_samples);
+  size_type lcp_bytes = sdsl::size_in_bytes(lcp);
   printHeader("Index size"); std::cout << inMegabytes(index_bytes) << " MB" << std::endl;
   printHeader("Without samples"); std::cout << inMegabytes(index_bytes - sample_bytes) << " MB" << std::endl;
+  printHeader("LCP size"); std::cout << inMegabytes(lcp_bytes) << " MB" << std::endl;
   std::cout << std::endl;
 
   if(verify) { verifyIndex(index, graph); }

--- a/dbg.cpp
+++ b/dbg.cpp
@@ -22,9 +22,6 @@
   SOFTWARE.
 */
 
-#include <cstdio>
-#include <cstdlib>
-
 #include "dbg.h"
 
 namespace gcsa

--- a/files.cpp
+++ b/files.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015 Genome Research Ltd.
+  Copyright (c) 2015, 2016 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
 
@@ -253,22 +253,26 @@ markSourceSinkNodes(std::vector<KMer>& kmers)
 const std::string InputGraph::BINARY_EXTENSION = ".graph";
 const std::string InputGraph::TEXT_EXTENSION = ".gcsa2";
 
-InputGraph::InputGraph(const std::vector<std::string>& files, bool binary_format)
+InputGraph::InputGraph(const std::vector<std::string>& files, bool binary_format) :
+  filenames(files), lcp_name(), binary(binary_format)
 {
-  this->filenames = files;
-  this->binary = binary_format;
   this->build();
 }
 
-InputGraph::InputGraph(size_type file_count, char** base_names, bool binary_format)
+InputGraph::InputGraph(size_type file_count, char** base_names, bool binary_format) :
+  lcp_name(), binary(binary_format)
 {
-  this->binary = binary_format;
   for(size_type file = 0; file < file_count; file++)
   {
     std::string filename = std::string(base_names[file]) + (this->binary ? BINARY_EXTENSION : TEXT_EXTENSION);
     this->filenames.push_back(filename);
   }
   this->build();
+}
+
+InputGraph::~InputGraph()
+{
+  TempFile::remove(this->lcp_name);
 }
 
 void

--- a/files.h
+++ b/files.h
@@ -70,10 +70,12 @@ void writeKMers(const std::string& base_name, std::vector<KMer>& kmers, size_typ
 struct InputGraph
 {
   std::vector<std::string> filenames;
+  std::string              lcp_name; // Used to pass the LCP array from GCSA construction.
   std::vector<size_type>   sizes;
 
   bool binary;
   size_type kmer_count, kmer_length;
+
 
   const static size_type UNKNOWN = ~(size_type)0;
   const static std::string BINARY_EXTENSION;  // .graph
@@ -81,6 +83,7 @@ struct InputGraph
 
   InputGraph(const std::vector<std::string>& files, bool binary_format);
   InputGraph(size_type file_count, char** base_names, bool binary_format);
+  ~InputGraph();
 
   void open(std::ifstream& input, size_type file) const;
   void setK(size_type new_k, size_type file);

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -414,6 +414,10 @@ MergedGraphReader::fromNodes(std::vector<node_type>& results)
 
 GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters, const Alphabet& _alpha)
 {
+#ifdef VERBOSE_STATUS_INFO
+  double start = readTimer(), stop;
+#endif
+
   if(graph.size() == 0) { return; }
   size_type bytes_required = graph.size() * (sizeof(PathNode) + 2 * sizeof(PathNode::rank_type));
   if(bytes_required > parameters.size_limit)
@@ -448,6 +452,12 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters, const Al
   // Create the initial PathGraph.
   PathGraph path_graph(graph, key_exists);
   sdsl::util::clear(key_exists);
+#ifdef VERBOSE_STATUS_INFO
+  stop = readTimer();
+  std::cerr << "GCSA::GCSA(): Preprocessing: " << (stop - start) << " seconds, "
+            << inGigabytes(memoryUsage()) << " GB" << std::endl;
+  start = stop;
+#endif
 
   // Prefix-doubling.
 #ifdef VERBOSE_STATUS_INFO
@@ -470,6 +480,12 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters, const Al
   this->header.path_nodes = merged_graph.size();
   path_graph.clear();
   sdsl::util::clear(lcp);
+#ifdef VERBOSE_STATUS_INFO
+  stop = readTimer();
+  std::cerr << "GCSA::GCSA(): Prefix-doubling: " << (stop - start) << " seconds, "
+            << inGigabytes(memoryUsage()) << " GB" << std::endl;
+  start = stop;
+#endif
 
   // Structures used for building GCSA.
   sdsl::int_vector<64> counts(mapper.alpha.sigma, 0); // alpha
@@ -648,6 +664,9 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters, const Al
   merged_graph.lcp_name.clear();
 
 #ifdef VERBOSE_STATUS_INFO
+  stop = readTimer();
+  std::cerr << "GCSA::GCSA(): Construction: " << (stop - start) << " seconds, "
+            << inGigabytes(memoryUsage()) << " GB" << std::endl;
   std::cerr << "GCSA::GCSA(): " << this->size() << " paths, " << this->edgeCount() << " edges" << std::endl;
   std::cerr << "GCSA::GCSA(): " << occ_count << " pointers (" << red_count << " redundant)" << std::endl;
   std::cerr << "GCSA::GCSA(): " << this->sampleCount() << " samples at "

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -671,13 +671,13 @@ GCSA::initSupport()
 bool
 GCSA::verifyIndex(std::vector<KMer>& kmers, size_type kmer_length) const
 {
-  return gcsa::verifyIndex(*this, kmers, kmer_length);
+  return gcsa::verifyIndex(*this, 0, kmers, kmer_length);
 }
 
 bool
 GCSA::verifyIndex(const InputGraph& graph) const
 {
-  return gcsa::verifyIndex(*this, graph);
+  return gcsa::verifyIndex(*this, 0, graph);
 }
 
 size_type

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -22,9 +22,6 @@
   SOFTWARE.
 */
 
-#include <cstdio>
-#include <cstdlib>
-
 #include "algorithms.h"
 #include "internal.h"
 #include "path_graph.h"
@@ -434,7 +431,7 @@ MergedGraphReader::fromNodes(std::vector<node_type>& results)
 
 //------------------------------------------------------------------------------
 
-GCSA::GCSA(const InputGraph& graph, const ConstructionParameters& parameters, const Alphabet& _alpha)
+GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters, const Alphabet& _alpha)
 {
   if(graph.size() == 0) { return; }
   size_type bytes_required = graph.size() * (sizeof(PathNode) + 2 * sizeof(PathNode::rank_type));
@@ -663,6 +660,11 @@ GCSA::GCSA(const InputGraph& graph, const ConstructionParameters& parameters, co
   this->stored_samples = sdsl::int_vector<0>(sample_buffer.size(), 0, sample_bits);
   for(size_type i = 0; i < sample_buffer.size(); i++) { this->stored_samples[i] = sample_buffer[i]; }
   sdsl::util::clear(sample_buffer);
+
+  // Transfer the LCP array from MergedGraph to InputGraph.
+  TempFile::remove(graph.lcp_name);
+  graph.lcp_name = merged_graph.lcp_name;
+  merged_graph.lcp_name.clear();
 
 #ifdef VERBOSE_STATUS_INFO
   std::cerr << "GCSA::GCSA(): " << this->size() << " paths, " << this->edgeCount() << " edges" << std::endl;

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -31,25 +31,6 @@ namespace gcsa
 
 //------------------------------------------------------------------------------
 
-ConstructionParameters::ConstructionParameters() :
-  doubling_steps(DOUBLING_STEPS), size_limit(SIZE_LIMIT * GIGABYTE)
-{
-}
-
-void
-ConstructionParameters::setSteps(size_type steps)
-{
-  this->doubling_steps = Range::bound(steps, 1, DOUBLING_STEPS);
-}
-
-void
-ConstructionParameters::setLimit(size_type gigabytes)
-{
-  this->size_limit = Range::bound(gigabytes, 1, ABSOLUTE_LIMIT) * GIGABYTE;
-}
-
-//------------------------------------------------------------------------------
-
 const std::string GCSA::EXTENSION = ".gcsa";
 
 GCSA::GCSA()

--- a/gcsa.h
+++ b/gcsa.h
@@ -36,22 +36,6 @@ namespace gcsa
 
 //------------------------------------------------------------------------------
 
-struct ConstructionParameters
-{
-  const static size_type DOUBLING_STEPS = 3;
-  const static size_type SIZE_LIMIT     = 500;    // Gigabytes.
-  const static size_type ABSOLUTE_LIMIT = 16384;  // Gigabytes.
-
-  ConstructionParameters();
-  void setSteps(size_type steps);
-  void setLimit(size_type gigabytes);
-
-  size_type doubling_steps;
-  size_type size_limit;
-};
-
-//------------------------------------------------------------------------------
-
 class GCSA
 {
 public:

--- a/gcsa.h
+++ b/gcsa.h
@@ -88,7 +88,7 @@ public:
     size limit. If the graph was encoded using non-default Alphabet, an alphabet object
     must also be supplied.
   */
-  GCSA(const InputGraph& graph, const ConstructionParameters& parameters = ConstructionParameters(),
+  GCSA(InputGraph& graph, const ConstructionParameters& parameters = ConstructionParameters(),
     const Alphabet& _alpha = Alphabet());
 
 //------------------------------------------------------------------------------

--- a/gcsa_format.cpp
+++ b/gcsa_format.cpp
@@ -201,7 +201,7 @@ GCSABody<BWTType, BitVector>::GCSABody(const GCSA& source)
 
   bwt_buffer = sdsl::int_vector_buffer<8>(filename);
   this->bwt = BWTType(bwt_buffer, source.bwt.size());
-  bwt_buffer.close(); remove(filename.c_str());
+  bwt_buffer.close(); TempFile::remove(filename);
   this->alpha = source.alpha;
 
   this->path_nodes = extract(source.path_nodes);

--- a/lcp.cpp
+++ b/lcp.cpp
@@ -1,0 +1,177 @@
+/*
+  Copyright (c) 2016 Genome Research Ltd.
+
+  Author: Jouni Siren <jouni.siren@iki.fi>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include "internal.h"
+#include "lcp.h"
+
+namespace gcsa
+{
+
+//------------------------------------------------------------------------------
+
+const std::string LCPArray::EXTENSION = ".lcp";
+
+LCPArray::LCPArray() :
+  lcp_size(0), branching_factor(2)
+{
+}
+
+LCPArray::LCPArray(const LCPArray& source)
+{
+  this->copy(source);
+}
+
+LCPArray::LCPArray(LCPArray&& source)
+{
+  *this = std::move(source);
+}
+
+LCPArray::~LCPArray()
+{
+}
+
+void
+LCPArray::copy(const LCPArray& source)
+{
+  this->data = source.data;
+  this->offsets = source.offsets;
+
+  this->lcp_size = source.lcp_size;
+  this->branching_factor = source.branching_factor;
+}
+
+void
+LCPArray::swap(LCPArray& another)
+{
+  if(this != &another)
+  {
+    this->data.swap(another.data);
+    this->offsets.swap(another.offsets);
+
+    std::swap(this->lcp_size, another.lcp_size);
+    std::swap(this->branching_factor, another.branching_factor);
+  }
+}
+
+LCPArray&
+LCPArray::operator=(const LCPArray& source)
+{
+  if(this != &source) { this->copy(source); }
+  return *this;
+}
+
+LCPArray&
+LCPArray::operator=(LCPArray&& source)
+{
+  if(this != &source)
+  {
+    this->data = std::move(source.data);
+    this->offsets = std::move(source.offsets);
+
+    this->lcp_size = std::move(source.lcp_size);
+    this->branching_factor = std::move(source.branching_factor);
+  }
+  return *this;
+}
+
+LCPArray::size_type
+LCPArray::serialize(std::ostream& out, sdsl::structure_tree_node* v, std::string name) const
+{
+  sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(v, name, sdsl::util::class_name(*this));
+  size_type written_bytes = 0;
+
+  written_bytes += this->data.serialize(out, child, "data");
+  written_bytes += this->offsets.serialize(out, child, "offsets");
+
+  written_bytes += sdsl::write_member(this->lcp_size, out, child, "lcp_size");
+  written_bytes += sdsl::write_member(this->branching_factor, out, child, "branching_factor");
+
+  sdsl::structure_tree::add_size(child, written_bytes);
+  return written_bytes;
+}
+
+void
+LCPArray::load(std::istream& in)
+{
+  this->data.load(in);
+  this->offsets.load(in);
+
+  sdsl::read_member(this->lcp_size, in);
+  sdsl::read_member(this->branching_factor, in);
+}
+
+//------------------------------------------------------------------------------
+
+LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parameters) :
+  branching_factor(parameters.lcp_branching)
+{
+  if(graph.lcp_name.empty())
+  {
+    std::cerr << "LCPArray::LCPArray: The input graph does not contain the LCP file" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  std::ifstream in(graph.lcp_name.c_str(), std::ios_base::binary);
+  if(!in)
+  {
+    std::cerr << "LCPArray::LCPArray: Cannot open LCP file " << graph.lcp_name << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  // Determine the number of levels.
+  this->lcp_size = fileSize(in);
+  size_type level_count = 1, level_size = this->lcp_size;
+  while(level_size > 1)
+  {
+    level_count++; level_size = (level_size + this->branching_factor - 1) / this->branching_factor;
+  }
+
+  // Initialize offsets.
+  this->offsets = sdsl::int_vector<64>(level_count + 1, 0);
+  level_size = this->lcp_size;
+  size_type total_size = this->lcp_size;
+  for(size_type level = 0; level < this->levels(); level++)
+  {
+    this->offsets[level + 1] = total_size;
+    level_size = (level_size + this->branching_factor - 1) / this->branching_factor;
+    total_size += level_size;
+  }
+
+  // Initialize data.
+  this->data = sdsl::int_vector<8>(total_size, ~(uint8_t)0);
+  DiskIO::read(in, (const uint8_t*)(this->data.data()), this->lcp_size);
+  in.close();
+  for(size_type level = 0; level < this->levels(); level++)
+  {
+    for(size_type i = this->offsets[level]; i < this->offsets[level + 1]; i++)
+    {
+      size_type par = this->rmtParent(i, level);
+      if(this->data[i] < this->data[par]) { this->data[par] = this->data[i]; }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace gcsa

--- a/lcp.cpp
+++ b/lcp.cpp
@@ -167,7 +167,7 @@ LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parame
   }
 
   // Initialize data.
-  this->data = sdsl::int_vector<8>(total_size, ~(uint8_t)0);
+  this->data = sdsl::int_vector<0>(total_size, ~(uint8_t)0, 8);
   DiskIO::read(in, (const uint8_t*)(this->data.data()), this->lcp_size);
   in.close();
   for(size_type level = 0; level < this->levels(); level++)
@@ -178,6 +178,7 @@ LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parame
       if(this->data[i] < this->data[par]) { this->data[par] = this->data[i]; }
     }
   }
+  sdsl::util::bit_compress(this->data);
 
 #ifdef VERBOSE_STATUS_INFO
   std::cerr << "LCPArray::LCPArray(): " << this->values() << " values at " << this->levels()

--- a/lcp.cpp
+++ b/lcp.cpp
@@ -134,6 +134,10 @@ LCPArray::load(std::istream& in)
 LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parameters) :
   branching_factor(parameters.lcp_branching)
 {
+#ifdef VERBOSE_STATUS_INFO
+  double start = readTimer();
+#endif
+
   if(graph.lcp_name.empty())
   {
     std::cerr << "LCPArray::LCPArray: The input graph does not contain the LCP file" << std::endl;
@@ -181,6 +185,9 @@ LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parame
   sdsl::util::bit_compress(this->data);
 
 #ifdef VERBOSE_STATUS_INFO
+  double seconds = readTimer() - start;
+  std::cerr << "LCPArray::LCPArray(): Construction: " << seconds << " seconds, "
+            << inGigabytes(memoryUsage()) << " GB" << std::endl;
   std::cerr << "LCPArray::LCPArray(): " << this->values() << " values at " << this->levels()
             << " levels (branching factor " << this->branching() << ")" << std::endl;
 #endif

--- a/lcp.cpp
+++ b/lcp.cpp
@@ -27,6 +27,14 @@
 
 namespace gcsa
 {
+//------------------------------------------------------------------------------
+
+std::ostream&
+operator<< (std::ostream& out, const STNode& node)
+{
+  out << "(" << node.left_lcp << ", " << node.range() << ", " << node.right_lcp << ")";
+  return out;
+}
 
 //------------------------------------------------------------------------------
 
@@ -144,18 +152,18 @@ LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parame
   size_type level_count = 1, level_size = this->lcp_size;
   while(level_size > 1)
   {
-    level_count++; level_size = (level_size + this->branching_factor - 1) / this->branching_factor;
+    level_count++; level_size = (level_size + this->branching() - 1) / this->branching();
   }
 
   // Initialize offsets.
   this->offsets = sdsl::int_vector<64>(level_count + 1, 0);
   level_size = this->lcp_size;
-  size_type total_size = this->lcp_size;
+  size_type total_size = 0;
   for(size_type level = 0; level < this->levels(); level++)
   {
-    this->offsets[level + 1] = total_size;
-    level_size = (level_size + this->branching_factor - 1) / this->branching_factor;
     total_size += level_size;
+    this->offsets[level + 1] = total_size;
+    level_size = (level_size + this->branching() - 1) / this->branching();
   }
 
   // Initialize data.
@@ -170,6 +178,152 @@ LCPArray::LCPArray(const InputGraph& graph, const ConstructionParameters& parame
       if(this->data[i] < this->data[par]) { this->data[par] = this->data[i]; }
     }
   }
+
+#ifdef VERBOSE_STATUS_INFO
+  std::cerr << "LCPArray::LCPArray(): " << this->values() << " values at " << this->levels()
+            << " levels (branching factor " << this->branching() << ")" << std::endl;
+#endif
+}
+
+//------------------------------------------------------------------------------
+
+STNode
+LCPArray::parent(const STNode& node) const
+{
+  if(node == this->root()) { return this->root(); }
+
+  range_type left(node.sp, node.left_lcp), right(node.ep + 1, node.right_lcp);
+  if(node.left_lcp >= node.right_lcp)
+  {
+    left = this->psv(node.sp);
+    if(left == this->notFound()) { left.first = 0; }
+  }
+  if(node.right_lcp >= node.left_lcp)
+  {
+    right = this->nsv(node.ep + 1);
+    if(right == this->notFound()) { right.first = this->size(); }
+  }
+
+  return STNode(left.first, right.first - 1, left.second, right.second);
+}
+
+STNode
+LCPArray::parent(range_type range) const
+{
+  return this->parent(this->nodeFor(range));
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  Find the last value less than 'val' between 'from' (inclusive) and 'to' (exclusive).
+  Return value will be lcp.notFound() if no such value exists.
+*/
+template<class Comparator>
+range_type
+psv(const LCPArray& lcp, size_type from, size_type to, size_type val, const Comparator& comp)
+{
+  while(to > from)
+  {
+    to--;
+    if(comp(lcp[to], val)) { return range_type(to, lcp[to]); }
+  }
+  return lcp.notFound();
+}
+
+template<class Comparator>
+range_type
+psv(const LCPArray& lcp, size_type to, const Comparator& comp)
+{
+  if(to == 0 || to >= lcp.size()) { return lcp.notFound(); }
+
+  // Find the children of the lowest common ancestor of psv(to) and 'to'.
+  size_type level = 0, val = lcp[to];
+  range_type res = lcp.notFound();
+  while(to != lcp.rmtRoot())
+  {
+    res = gcsa::psv(lcp, lcp.rmtFirstSibling(to, level), to, val, comp);
+    if(res.first < lcp.values()) { break; }
+    to = lcp.rmtParent(to, level); level++;
+  }
+  if(res.first >= lcp.values()) { return res; } // Not found.
+
+  // Go to the leaf containing psv(to).
+  while(level > 0)
+  {
+    size_type from = lcp.rmtFirstChild(res.first, level); level--;
+    res = gcsa::psv(lcp, from, lcp.rmtLastSibling(from, level) + 1, val, comp);
+  }
+
+  return res;
+}
+
+range_type
+LCPArray::psv(size_type pos) const
+{
+  return gcsa::psv(*this, pos, std::less<size_type>());
+}
+
+range_type
+LCPArray::psev(size_type pos) const
+{
+  return gcsa::psv(*this, pos, std::less_equal<size_type>());
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  Find the first value less than 'val' between 'from' and 'to' (inclusive).
+  Return value will be lcp.notFound() if no such value exists.
+*/
+template<class Comparator>
+range_type
+nsv(const LCPArray& lcp, size_type from, size_type to, size_type val, const Comparator& comp)
+{
+  for(size_type i = from; i <= to; i++)
+  {
+    if(comp(lcp[i], val)) { return range_type(i, lcp[i]); }
+  }
+  return lcp.notFound();
+}
+
+template<class Comparator>
+range_type
+nsv(const LCPArray& lcp, size_type from, const Comparator& comp)
+{
+  if(from + 1 >= lcp.size()) { return lcp.notFound(); }
+
+  // Find the children of the lowest common ancestor for 'from' and nsv(from).
+  size_type level = 0, val = lcp[from];
+  range_type res = lcp.notFound();
+  while(from != lcp.rmtRoot())
+  {
+    res = gcsa::nsv(lcp, from + 1, lcp.rmtLastSibling(from, level), val, comp);
+    if(res.first < lcp.values()) { break; }
+    from = lcp.rmtParent(from, level); level++;
+  }
+  if(res.first >= lcp.values()) { return res; }
+
+  // Go to the leaf containing nsv(to).
+  while(level > 0)
+  {
+    from = lcp.rmtFirstChild(res.first, level); level--;
+    res = gcsa::nsv(lcp, from, lcp.rmtLastSibling(from, level), val, comp);
+  }
+
+  return res;
+}
+
+range_type
+LCPArray::nsv(size_type pos) const
+{
+  return gcsa::nsv(*this, pos, std::less<size_type>());
+}
+
+range_type
+LCPArray::nsev(size_type pos) const
+{
+  return gcsa::nsv(*this, pos, std::less_equal<size_type>());
 }
 
 //------------------------------------------------------------------------------

--- a/lcp.h
+++ b/lcp.h
@@ -1,0 +1,148 @@
+/*
+  Copyright (c) 2016 Genome Research Ltd.
+
+  Author: Jouni Siren <jouni.siren@iki.fi>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#ifndef _GCSA_LCP_H
+#define _GCSA_LCP_H
+
+#include "files.h"
+
+namespace gcsa
+{
+
+/*
+  dbg.h: Specialization of GCSA for de Bruijn graphs.
+*/
+
+//------------------------------------------------------------------------------
+
+/*
+  This is a specialization of GCSA for de Bruijn graphs. Because the graph is
+  reverse deterministic, we can use indicator bitvectors for encoding the BWT.
+  This simplifies LF() to two rank() operations.
+*/
+
+class LCPArray
+{
+public:
+  typedef gcsa::size_type size_type;
+
+//------------------------------------------------------------------------------
+
+  LCPArray();
+  LCPArray(const LCPArray& source);
+  LCPArray(LCPArray&& source);
+  ~LCPArray();
+
+  void swap(LCPArray& another);
+  LCPArray& operator=(const LCPArray& source);
+  LCPArray& operator=(LCPArray&& source);
+
+  size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
+  void load(std::istream& in);
+
+  const static std::string EXTENSION; // .lcp
+
+//------------------------------------------------------------------------------
+
+  /*
+    The InputGraph instance must be the same that has already been used for GCSA construction.
+    The graph passes the temporary file containing the LCP array from GCSA construction to
+    LCPArray construction.
+  */
+
+  explicit LCPArray(const InputGraph& graph, const ConstructionParameters& parameters = ConstructionParameters());
+
+//------------------------------------------------------------------------------
+
+  inline size_type size() const { return this->lcp_size; }
+  inline size_type levels() const { return this->offsets.size() - 1; }
+
+  // FIXME queries
+
+//------------------------------------------------------------------------------
+
+  /*
+    We store a k-ary range minimum tree over the LCP array. Each node is identified by
+    itse position in the data array. Level i occupies range [offsets[i], offsets[i + 1] - 1]
+    in the array. Level 0 is the leaves (the LCP array).
+  */
+
+  sdsl::int_vector<8>  data;
+  sdsl::int_vector<64> offsets;
+  size_type            lcp_size, branching_factor;
+
+private:
+  void copy(const LCPArray& source);
+
+//------------------------------------------------------------------------------
+
+  /*
+    Tree operations on the range minimum tree. If level is required, it refers to the
+    level of the parameter node.
+  */
+
+  inline size_type rmtRoot() const
+  {
+    return this->data.size() - 1;
+  }
+
+  inline size_type rmtLevel(size_type node) const
+  {
+    size_type level = 0;
+    while(this->offsets[level + 1] <= node) { level++; }
+    return level;
+  }
+
+  inline size_type rmtParent(size_type node, size_type level) const
+  {
+    return this->offsets[level + 1] + (node - this->offsets[level]) / this->branching_factor;
+  }
+
+  inline size_type rmtFirstSibling(size_type last_child, size_type level) const
+  {
+    return last_child - (last_child - this->offsets[level]) % this->branching_factor;
+  }
+
+  inline size_type rmtLastSibling(size_type first_child, size_type level) const
+  {
+    return std::min(this->offsets[level + 1] - 1, first_child + this->branching_factor - 1);
+  }
+
+  inline size_type rmtFirstChild(size_type node, size_type level) const
+  {
+    return this->offsets[level - 1] + (node - this->offsets[level]) * this->branching_factor;
+  }
+
+  inline size_type rmtLastChild(size_type node, size_type level) const
+  {
+    return this->rmtLastSibling(this->rmtFirstChild(node, level), level - 1);
+  }
+
+};  // class LCPArray
+
+//------------------------------------------------------------------------------
+
+} // namespace gcsa
+
+#endif // _GCSA_LCP_H

--- a/lcp.h
+++ b/lcp.h
@@ -156,7 +156,7 @@ public:
     in the array. Level 0 is the leaves (the LCP array).
   */
 
-  sdsl::int_vector<8>  data;
+  sdsl::int_vector<0>  data;
   sdsl::int_vector<64> offsets;
   size_type            lcp_size, branching_factor;
 
@@ -173,7 +173,7 @@ private:
 public:
   inline size_type rmtRoot() const
   {
-    return this->data.size() - 1;
+    return this->values() - 1;
   }
 
   inline size_type rmtParent(size_type node, size_type level) const

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -1102,7 +1102,6 @@ MergedGraph::MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, c
 
   PathGraphMerger merger(source, kmer_lcp, false);
   std::vector<range_type> curr_from;
-  std::vector<uint8_t> lcp_buffer; lcp_buffer.reserve(MEGABYTE);
   size_type curr_comp = 0;  // Used to transform next.
   for(range_type range = merger.first(); !(merger.atEnd(range)); range = merger.next())
   {

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -22,7 +22,6 @@
   SOFTWARE.
 */
 
-#include <cstring>
 #include <deque>
 
 #include "internal.h"
@@ -867,7 +866,7 @@ PathGraph::clear()
 {
   for(size_type file = 0; file < this->files(); file++)
   {
-    remove(this->filenames[file].c_str());
+    TempFile::remove(this->filenames[file]);
   }
   this->filenames.clear();
   this->sizes.clear();
@@ -1143,10 +1142,10 @@ MergedGraph::~MergedGraph()
 void
 MergedGraph::clear()
 {
-  remove(this->path_name.c_str()); this->path_name = "";
-  remove(this->rank_name.c_str()); this->rank_name = "";
-  remove(this->from_name.c_str()); this->from_name = "";
-  remove(this->lcp_name.c_str()); this->lcp_name = "";
+  TempFile::remove(this->path_name);
+  TempFile::remove(this->rank_name);
+  TempFile::remove(this->from_name);
+  TempFile::remove(this->lcp_name);
 
   this->path_count = 0; this->rank_count = 0; this->from_count = 0;
   this->order = 0;

--- a/path_graph.h
+++ b/path_graph.h
@@ -41,7 +41,7 @@ struct PathLabel
 {
   typedef std::uint32_t rank_type;
 
-  // This should be at least 1 << GCSA::DOUBLING_STEPS.
+  // This should be at least 1 << ConstructionParameters::DOUBLING_STEPS.
   const static size_type LABEL_LENGTH = 8;
 
   // Labels starting with NO_RANK will be after real labels in lexicographic order.
@@ -380,10 +380,11 @@ struct MergedGraph
   inline size_type path_bytes() const { return this->size() * sizeof(PathNode); }
   inline size_type rank_bytes() const { return this->ranks() * sizeof(PathNode::rank_type); }
   inline size_type from_bytes() const { return this->extra() * sizeof(range_type); }
+  inline size_type lcp_bytes() const { return this->size(); }
 
   inline size_type bytes() const
   {
-    return this->path_bytes() + this->rank_bytes() + this->from_bytes();
+    return this->path_bytes() + this->rank_bytes() + this->from_bytes() + this->lcp_bytes();
   }
 
   MergedGraph(const MergedGraph&) = delete;

--- a/support.cpp
+++ b/support.cpp
@@ -29,6 +29,32 @@ namespace gcsa
 
 //------------------------------------------------------------------------------
 
+ConstructionParameters::ConstructionParameters() :
+  doubling_steps(DOUBLING_STEPS), size_limit(SIZE_LIMIT * GIGABYTE),
+  lcp_branching(LCP_BRANCHING)
+{
+}
+
+void
+ConstructionParameters::setSteps(size_type steps)
+{
+  this->doubling_steps = Range::bound(steps, 1, DOUBLING_STEPS);
+}
+
+void
+ConstructionParameters::setLimit(size_type gigabytes)
+{
+  this->size_limit = Range::bound(gigabytes, 1, ABSOLUTE_LIMIT) * GIGABYTE;
+}
+
+void
+ConstructionParameters::setLCPBranching(size_type factor)
+{
+  this->lcp_branching = std::max((size_type)2, factor);
+}
+
+//------------------------------------------------------------------------------
+
 /*
   The default alphabet interprets \0 and $ as endmarkers, ACGT and acgt as ACGT,
   # as a the label of the source node, and the and the remaining characters as N.

--- a/support.h
+++ b/support.h
@@ -36,6 +36,25 @@ namespace gcsa
 
 //------------------------------------------------------------------------------
 
+struct ConstructionParameters
+{
+  const static size_type DOUBLING_STEPS = 3;
+  const static size_type SIZE_LIMIT     = 500;    // Gigabytes.
+  const static size_type ABSOLUTE_LIMIT = 16384;  // Gigabytes.
+  const static size_type LCP_BRANCHING  = 32;
+
+  ConstructionParameters();
+  void setSteps(size_type steps);
+  void setLimit(size_type gigabytes);
+  void setLCPBranching(size_type factor);
+
+  size_type doubling_steps;
+  size_type size_limit;
+  size_type lcp_branching;
+};
+
+//------------------------------------------------------------------------------
+
 template<class ByteVector>
 void characterCounts(const ByteVector& sequence, const sdsl::int_vector<8>& char2comp, sdsl::int_vector<64>& counts);
 

--- a/support.h
+++ b/support.h
@@ -41,7 +41,7 @@ struct ConstructionParameters
   const static size_type DOUBLING_STEPS = 3;
   const static size_type SIZE_LIMIT     = 500;    // Gigabytes.
   const static size_type ABSOLUTE_LIMIT = 16384;  // Gigabytes.
-  const static size_type LCP_BRANCHING  = 32;
+  const static size_type LCP_BRANCHING  = 64;
 
   ConstructionParameters();
   void setSteps(size_type steps);

--- a/utils.cpp
+++ b/utils.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015 Genome Research Ltd.
+  Copyright (c) 2015, 2016 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
 
@@ -22,6 +22,7 @@
   SOFTWARE.
 */
 
+#include <cstdio>
 #include <cstdlib>
 
 #include <sys/resource.h>
@@ -105,6 +106,16 @@ TempFile::getName(const std::string& name_part)
     + std::string(hostname) + '_'
     + sdsl::util::to_string(sdsl::util::pid()) + '_'
     + sdsl::util::to_string(sdsl::util::id());
+}
+
+void
+TempFile::remove(std::string& filename)
+{
+  if(!(filename.empty()))
+  {
+    std::remove(filename.c_str());
+    filename.clear();
+  }
 }
 
 size_type

--- a/utils.h
+++ b/utils.h
@@ -195,6 +195,7 @@ struct TempFile
 
   static void setDirectory(const std::string& directory);
   static std::string getName(const std::string& name_part);
+  static void remove(std::string& filename);
 };
 
 // Returns the total length of the rows, excluding line ends.


### PR DESCRIPTION
Add LCP array and `parent()` queries to the index.

`LCPArray` is a separate class not contained in `GCSA`. It is not needed for basic index functionality, while it increases the size of the index by a nontrivial amount (30-40% or 4+d bits per path node, where d is the number of doubling steps). The LCP array might also add significant bloat to the public interface of `GCSA`, if the full suffix tree functionality is implemented.

In principle, the LCP array with support for next/previous smaller value queries and range minimum queries is enough to support the entire functionality of the suffix tree. At the moment it is still uncertain what a suffix tree over a (pruned) de Bruijn graph really is. We also don't have inverse suffix array functionality in GCSA, which would be needed for some suffix tree operations.
