### PR TITLE
Simplified I/O

### DIFF
--- a/convert_graph.cpp
+++ b/convert_graph.cpp
@@ -35,7 +35,7 @@ main(int argc, char** argv)
   if(argc < 2)  // From stdin to stdout.
   {
     std::vector<KMer> kmers;
-    size_type kmer_length = readText(std::cin, kmers);
+    size_type kmer_length = readText(std::cin, kmers, Alphabet());
     writeBinary(std::cout, kmers, kmer_length);
   }
   else

--- a/dbg.cpp
+++ b/dbg.cpp
@@ -159,7 +159,7 @@ DeBruijnGraph::load(std::istream& in)
 
 //------------------------------------------------------------------------------
 
-DeBruijnGraph::DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha)
+DeBruijnGraph::DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& alphabet)
 {
   this->node_count = keys.size();
   this->graph_order = kmer_length;
@@ -167,13 +167,13 @@ DeBruijnGraph::DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_l
   size_type total_edges = 0;
   for(size_type i = 0; i < keys.size(); i++) { total_edges += sdsl::bits::lt_cnt[Key::predecessors(keys[i])]; }
 
-  sdsl::int_vector<64> counts(_alpha.sigma, 0);
-  bit_vector bwt_buffer(_alpha.sigma * total_edges, 0);
+  sdsl::int_vector<64> counts(alphabet.sigma, 0);
+  bit_vector bwt_buffer(alphabet.sigma * total_edges, 0);
   bit_vector node_buffer(total_edges, 0);
   for(size_type i = 0, edge_pos = 0; i < keys.size(); i++)
   {
     size_type pred = Key::predecessors(keys[i]);
-    for(size_type j = 0; j < _alpha.sigma; j++)
+    for(size_type j = 0; j < alphabet.sigma; j++)
     {
       if(pred & (((size_type)1) << j))
       {
@@ -184,7 +184,7 @@ DeBruijnGraph::DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_l
     edge_pos += sdsl::bits::lt_cnt[Key::successors(keys[i])];
     node_buffer[edge_pos - 1] = 1;
   }
-  this->alpha = Alphabet(counts, _alpha.char2comp, _alpha.comp2char);
+  this->alpha = Alphabet(counts, alphabet.char2comp, alphabet.comp2char);
   this->bwt = bwt_buffer; sdsl::util::clear(bwt_buffer);
   this->nodes = node_buffer; sdsl::util::clear(node_buffer);
 

--- a/dbg.h
+++ b/dbg.h
@@ -71,7 +71,7 @@ public:
     The input vector must be sorted and contain only unique kmers of length 16 or less.
     Each kmer must have at least one predecessor and one successor.
   */
-  DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& _alpha = Alphabet());
+  DeBruijnGraph(const std::vector<key_type>& keys, size_type kmer_length, const Alphabet& alphabet);
 
 //------------------------------------------------------------------------------
 

--- a/files.cpp
+++ b/files.cpp
@@ -503,12 +503,15 @@ GCSAHeader::checkNew() const
 void
 GCSAHeader::swap(GCSAHeader& another)
 {
-  std::swap(this->tag, another.tag);
-  std::swap(this->version, another.version);
-  std::swap(this->path_nodes, another.path_nodes);
-  std::swap(this->edges, another.edges);
-  std::swap(this->order, another.order);
-  std::swap(this->flags, another.flags);
+  if(this != &another)
+  {
+    std::swap(this->tag, another.tag);
+    std::swap(this->version, another.version);
+    std::swap(this->path_nodes, another.path_nodes);
+    std::swap(this->edges, another.edges);
+    std::swap(this->order, another.order);
+    std::swap(this->flags, another.flags);
+  }
 }
 
 std::ostream& operator<<(std::ostream& stream, const GCSAHeader& header)

--- a/files.cpp
+++ b/files.cpp
@@ -61,11 +61,10 @@ tokenize(const std::string& line, std::vector<std::string>& tokens)
 }
 
 size_type
-readText(std::istream& in, std::vector<KMer>& kmers, bool append)
+readText(std::istream& in, std::vector<KMer>& kmers, const Alphabet& alpha, bool append)
 {
   if(!append) { sdsl::util::clear(kmers); }
 
-  Alphabet alpha;
   size_type kmer_length = ~(size_type)0;
   while(true)
   {
@@ -254,14 +253,14 @@ markSourceSinkNodes(std::vector<KMer>& kmers)
 const std::string InputGraph::BINARY_EXTENSION = ".graph";
 const std::string InputGraph::TEXT_EXTENSION = ".gcsa2";
 
-InputGraph::InputGraph(const std::vector<std::string>& files, bool binary_format) :
-  filenames(files), lcp_name(), binary(binary_format)
+InputGraph::InputGraph(const std::vector<std::string>& files, bool binary_format, const Alphabet& alphabet) :
+  filenames(files), lcp_name(), alpha(alphabet), binary(binary_format)
 {
   this->build();
 }
 
-InputGraph::InputGraph(size_type file_count, char** base_names, bool binary_format) :
-  lcp_name(), binary(binary_format)
+InputGraph::InputGraph(size_type file_count, char** base_names, bool binary_format, const Alphabet& alphabet) :
+  lcp_name(), alpha(alphabet), binary(binary_format)
 {
   for(size_type file = 0; file < file_count; file++)
   {
@@ -384,7 +383,7 @@ InputGraph::read(std::vector<KMer>& kmers, size_type file, bool append) const
 
   std::ifstream input; this->open(input, file);
   if(!append) { kmers.reserve(this->sizes[file]); }
-  size_type new_k = (this->binary ? readBinary(input, kmers, append) : readText(input, kmers, append));
+  size_type new_k = (this->binary ? readBinary(input, kmers, append) : readText(input, kmers, this->alpha, append));
   this->checkK(new_k, file);
   input.close();
 

--- a/files.h
+++ b/files.h
@@ -55,7 +55,7 @@ struct GraphFileHeader
   return value is kmer length.
 */
 size_type readBinary(std::istream& in, std::vector<KMer>& kmers, bool append = false);
-size_type readText(std::istream& in, std::vector<KMer>& kmers, bool append = false);
+size_type readText(std::istream& in, std::vector<KMer>& kmers, const Alphabet& alpha, bool append = false);
 
 // FIXME Later: writeText()
 void writeBinary(std::ostream& out, std::vector<KMer>& kmers, size_type kmer_length);
@@ -73,6 +73,8 @@ struct InputGraph
   std::string              lcp_name; // Used to pass the LCP array from GCSA construction.
   std::vector<size_type>   sizes;
 
+  Alphabet                 alpha;
+
   bool binary;
   size_type kmer_count, kmer_length;
 
@@ -81,8 +83,8 @@ struct InputGraph
   const static std::string BINARY_EXTENSION;  // .graph
   const static std::string TEXT_EXTENSION;    // .gcsa2
 
-  InputGraph(const std::vector<std::string>& files, bool binary_format);
-  InputGraph(size_type file_count, char** base_names, bool binary_format);
+  InputGraph(const std::vector<std::string>& files, bool binary_format, const Alphabet& alphabet = Alphabet());
+  InputGraph(size_type file_count, char** base_names, bool binary_format, const Alphabet& alphabet = Alphabet());
   ~InputGraph();
 
   void open(std::ifstream& input, size_type file) const;

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -268,9 +268,9 @@ void
 MergedGraphReader::init(const MergedGraph& graph,
   const DeBruijnGraph* _mapper, const sdsl::int_vector<0>* _last_char)
 {
-  this->paths.init(graph.path_name);
-  this->labels.init(graph.rank_name);
-  this->from_nodes.init(graph.from_name);
+  this->paths.open(graph.path_name);
+  this->labels.open(graph.rank_name);
+  this->from_nodes.open(graph.from_name);
 
   this->path = this->rank = this->from = 0;
   this->seek();
@@ -282,9 +282,9 @@ MergedGraphReader::init(const MergedGraph& graph,
 void
 MergedGraphReader::init(const MergedGraph& graph, size_type comp)
 {
-  this->paths.init(graph.path_name);
-  this->labels.init(graph.rank_name);
-  this->from_nodes.init(graph.from_name);
+  this->paths.open(graph.path_name);
+  this->labels.open(graph.rank_name);
+  this->from_nodes.open(graph.from_name);
 
   this->path = graph.next[comp];
   this->from = graph.next_from[comp];
@@ -515,7 +515,7 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters)
   {
     reader[comp + 1].init(merged_graph, comp);
   }
-  ReadBuffer<uint8_t> lcp_array; lcp_array.init(merged_graph.lcp_name);
+  ReadBuffer<uint8_t> lcp_array; lcp_array.open(merged_graph.lcp_name);
 
   // The actual construction.
   PathLabel first, last;

--- a/gcsa.h
+++ b/gcsa.h
@@ -69,11 +69,9 @@ public:
     This is the main constructor. We build GCSA from the graph according to the parameters,
     using a given number of doubling steps. The construction is mostly disk-based. There
     are at most two graphs on disk at once, and the size of each graph is bounded by the
-    size limit. If the graph was encoded using non-default Alphabet, an alphabet object
-    must also be supplied.
+    size limit.
   */
-  GCSA(InputGraph& graph, const ConstructionParameters& parameters = ConstructionParameters(),
-    const Alphabet& _alpha = Alphabet());
+  GCSA(InputGraph& graph, const ConstructionParameters& parameters = ConstructionParameters());
 
 //------------------------------------------------------------------------------
 

--- a/internal.cpp
+++ b/internal.cpp
@@ -58,7 +58,7 @@ CounterArray::clear()
 void
 CounterArray::swap(CounterArray& another)
 {
-  if(this != another)
+  if(this != &another)
   {
     this->data.swap(another.data);
     this->large_values.swap(another.large_values);

--- a/internal.cpp
+++ b/internal.cpp
@@ -58,11 +58,14 @@ CounterArray::clear()
 void
 CounterArray::swap(CounterArray& another)
 {
-  this->data.swap(another.data);
-  this->large_values.swap(another.large_values);
-  std::swap(this->width, another.width);
-  std::swap(this->large_value, another.large_value);
-  std::swap(this->total, another.total);
+  if(this != another)
+  {
+    this->data.swap(another.data);
+    this->large_values.swap(another.large_values);
+    std::swap(this->width, another.width);
+    std::swap(this->large_value, another.large_value);
+    std::swap(this->total, another.total);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/internal.h
+++ b/internal.h
@@ -200,7 +200,8 @@ struct PriorityQueue
   PriorityQueue();
   explicit PriorityQueue(size_type n) : data(n) { }
 
-  void resize(size_type n) { this->data.resize(n); }
+  inline void clear() { this->data.clear(); }
+  inline void resize(size_type n) { this->data.resize(n); }
 
   inline size_type size() const { return this->data.size(); }
   inline static size_type parent(size_type i) { return (i - 1) / 2; }
@@ -248,198 +249,87 @@ PriorityQueue<Element>::heapify()
 //------------------------------------------------------------------------------
 
 /*
-  A buffer for reading a file of Elements sequentially. The buffer contains Elements
-  offset to offset + buffer.size() - 1. The offset is moved by calling seek() or when
-  accessing an element before the current offset.
-
-  A separate thread is spawned for reading in the background.
-
-  The Reader must implement the following interface:
-
-  Reader()                        Default constructor.
-  init(parameters...)             Initialize the reader.
-  close()                         Close the reader.
-  size()                          Return the size of the source data.
-  append(buffer, n, read_buffer)  Append n elements to buffer. read_buffer can be used as
-                                  a buffer if necessary. Its capacity should be > 0.
-  read(read_buffer)               Read read_buffer.size() elements.
-  seek(i)                         Go to offset i.
-  finish()                        Finish reading.
-  finished()                      Has reading finished (at end or by calling finish())?
+  A buffer that keeps Elements [offset, offset + size - 1] in memory. It supports
+  seeking to a new position and adding Elements to the end.
 */
 
-template<class Element, class Reader>
-struct OldReadBuffer
+template<class Element>
+struct BufferWindow
 {
-  // Main thread.
-  size_type               offset;
-  std::deque<Element>     buffer;
-  Reader                  reader;
+  std::deque<Element> data;
+  size_type           offset;
 
-  // Reader thread.
-  std::vector<Element>    read_buffer;
-  std::mutex              mtx;
-  std::condition_variable empty;
-  std::thread             reader_thread;
+  BufferWindow();
+  ~BufferWindow();
 
-  // Minimum size when refilling the buffer.
-  const static size_type BUFFER_SIZE = MEGABYTE;
-
-  // Refill the buffer if its size falls below this threshold.
-  const static size_type MINIMUM_SIZE = BUFFER_SIZE / 2;
-
-  // Read this many elements at once.
-  const static size_type READ_BUFFER_SIZE = BUFFER_SIZE;
-
-  OldReadBuffer();
-  ~OldReadBuffer();
-
-  template<class... ReaderParameters> void init(ReaderParameters... parameters);
-  void close();
-
-  inline size_type size() const { return this->reader.size(); }
+  inline size_type size() const { return this->data.size(); }
   inline bool buffered(size_type i) const
   {
-    return (i >= this->offset && i < this->offset + this->buffer.size());
+    return (i >= this->offset && i < this->offset + this->size());
   }
 
   /*
     Beware: Calling seek() may invalidate the reference. The same may also happen when
     calling operator[] with a non-buffered position.
   */
-  inline Element& operator[] (size_type i)
-  {
-    if(!(this->buffered(i))) { this->read(i); }
-    return this->buffer[i - this->offset];
-  }
-  void seek(size_type i); // Set offset to i.
+  inline Element& operator[] (size_type i) { return this->data[i - this->offset]; }
+  inline const Element& operator[] (size_type i) const { return this->data[i - this->offset]; }
 
-  // Internal functions.
-  bool fill();            // Fill the read buffer.
-  void read(size_type i); // Read i into buffer, possibly seeking backwards.
-  void addBlock();        // Add a block into buffer, assuming that this read holds mtx.
+  void clear();
+  void seek(size_type i);
+  void swap(BufferWindow<Element>& another);
 
-  OldReadBuffer(const OldReadBuffer&) = delete;
-  OldReadBuffer& operator= (const OldReadBuffer&) = delete;
+  inline void push_back(const Element& element) { this->data.push_back(element); }
+
+  template<class Iterator>
+  void insert(Iterator from, Iterator to) { this->data.insert(this->data.end(), from, to); }
 };
 
-template<class Element, class Reader>
-OldReadBuffer<Element, Reader>::OldReadBuffer()
+template<class Element>
+BufferWindow<Element>::BufferWindow() :
+  offset(0)
 {
+}
+
+template<class Element>
+BufferWindow<Element>::~BufferWindow()
+{
+}
+
+template<class Element>
+void
+BufferWindow<Element>::clear()
+{
+  sdsl::util::clear(this->data);
   this->offset = 0;
-  this->read_buffer.reserve(READ_BUFFER_SIZE);
 }
 
-template<class Element, class Reader>
-OldReadBuffer<Element, Reader>::~OldReadBuffer()
-{
-  this->close();
-}
-
-template<class Element, class Reader>
+template<class Element>
 void
-readerThread(OldReadBuffer<Element, Reader>* buffer)
+BufferWindow<Element>::seek(size_type i)
 {
-  while(!(buffer->fill()));
-}
-
-template<class Element, class Reader>
-template<class... ReaderParameters>
-void
-OldReadBuffer<Element, Reader>::init(ReaderParameters... parameters)
-{
-  this->reader.init(parameters...);
-  this->reader_thread = std::thread(readerThread<Element, Reader>, this);
-}
-
-template<class Element, class Reader>
-void
-OldReadBuffer<Element, Reader>::close()
-{
-  // We need to stop the reader thread.
-  this->mtx.lock();
-  this->reader.finish();
-  this->read_buffer.clear();
-  this->empty.notify_one();
-  this->mtx.unlock();
-  if(this->reader_thread.joinable()) { this->reader_thread.join(); }
-
-  sdsl::util::clear(this->buffer);
-  sdsl::util::clear(this->read_buffer);
-  this->reader.close();
-}
-
-template<class Element, class Reader>
-void
-OldReadBuffer<Element, Reader>::seek(size_type i)
-{
-  if(i >= this->size()) { return; }
-
   if(this->buffered(i))
   {
-    while(this->offset < i) { this->buffer.pop_front(); this->offset++; }
+    for(size_type j = this->offset; j < i; j++) { this->data.pop_front(); }
   }
-  else
-  {
-    std::unique_lock<std::mutex> lock(this->mtx);
-    this->buffer.clear(); this->read_buffer.clear();
-    this->reader.seek(i); this->offset = i;
-  }
-  if(this->buffer.size() < MINIMUM_SIZE)
-  {
-    std::unique_lock<std::mutex> lock(this->mtx);
-    this->addBlock();
-    this->empty.notify_one();
-  }
+  else { this->data.clear(); }
+  this->offset = i;
 }
 
-template<class Element, class Reader>
-bool
-OldReadBuffer<Element, Reader>::fill()
-{
-  std::unique_lock<std::mutex> lock(this->mtx);
-  this->empty.wait(lock, [this]() { return read_buffer.empty(); } );
-
-  this->read_buffer.resize(READ_BUFFER_SIZE);
-  this->reader.read(this->read_buffer);
-
-  return this->reader.finished();
-}
-
-template<class Element, class Reader>
+template<class Element>
 void
-OldReadBuffer<Element, Reader>::read(size_type i)
+BufferWindow<Element>::swap(BufferWindow<Element>& another)
 {
-  if(i >= this->size()) { return; }
-  if(i < this->offset) { this->seek(i); return; }
-
-  std::unique_lock<std::mutex> lock(this->mtx);
-  while(!(this->buffered(i))) { this->addBlock(); }
-  this->empty.notify_one();
-}
-
-template<class Element, class Reader>
-void
-OldReadBuffer<Element, Reader>::addBlock()
-{
-  if(this->read_buffer.empty())
-  {
-    this->reader.append(this->buffer, READ_BUFFER_SIZE, this->read_buffer);
-  }
-  else
-  {
-    this->buffer.insert(this->buffer.end(), this->read_buffer.begin(), this->read_buffer.end());
-    this->read_buffer.clear();
-  }
+  this->data.swap(another.data);
+  std::swap(this->offset, another.offset);
 }
 
 //------------------------------------------------------------------------------
 
-
 /*
-  A buffer for reading a file of Elements sequentially. The buffer contains Elements
-  offset to offset + buffer.size() - 1. The offset is moved by calling seek() or when
-  accessing an element before the current offset.
+  A buffer for reading a file of Elements sequentially. Function seek() moves the start
+  of the buffer to the new position. Accesses before the current start call seek(), while
+  accesses after it expand the buffer until the requested position is contained in it.
 
   A separate thread is spawned for reading in the background. The reader thread stops
   when it reaches the end of the file.
@@ -449,8 +339,7 @@ template<class Element>
 struct ReadBuffer
 {
   // Main thread.
-  size_type               offset;
-  std::deque<Element>     buffer;
+  BufferWindow<Element>   buffer;
 
   // File
   std::ifstream           file;
@@ -471,14 +360,10 @@ struct ReadBuffer
   ReadBuffer();
   ~ReadBuffer();
 
-  void init(const std::string& filename);
+  void open(const std::string& filename);
   void close();
 
   inline size_type size() const { return this->elements; }
-  inline bool buffered(size_type i) const
-  {
-    return (i >= this->offset && i < this->offset + this->buffer.size());
-  }
 
   /*
     Beware: Calling seek() may invalidate the reference. The same may also happen when
@@ -486,8 +371,8 @@ struct ReadBuffer
   */
   inline Element& operator[] (size_type i)
   {
-    if(!(this->buffered(i))) { this->read(i); }
-    return this->buffer[i - this->offset];
+    if(!(this->buffer.buffered(i))) { this->read(i); }
+    return this->buffer[i];
   }
 
   void seek(size_type i); // Set offset to i.
@@ -504,7 +389,6 @@ struct ReadBuffer
 template<class Element>
 ReadBuffer<Element>::ReadBuffer()
 {
-  this->offset = 0;
   this->elements = 0; this->file_offset = 0;
   this->read_buffer.reserve(READ_BUFFER_SIZE);
 }
@@ -524,18 +408,18 @@ readerThread(ReadBuffer<Element>* buffer)
 
 template<class Element>
 void
-ReadBuffer<Element>::init(const std::string& filename)
+ReadBuffer<Element>::open(const std::string& filename)
 {
   if(this->file.is_open())
   {
-    std::cerr << "ReadBuffer::init(): The file is already open" << std::endl;
+    std::cerr << "ReadBuffer::open(): The file is already open" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
   this->file.open(filename.c_str(), std::ios_base::binary);
   if(!(this->file))
   {
-    std::cerr << "ReadBuffer::init(): Cannot open input file " << filename << std::endl;
+    std::cerr << "ReadBuffer::open(): Cannot open input file " << filename << std::endl;
     std::exit(EXIT_FAILURE);
   }
   this->elements = fileSize(this->file) / sizeof(Element);
@@ -568,17 +452,16 @@ ReadBuffer<Element>::seek(size_type i)
 {
   if(i >= this->size()) { return; }
 
-  if(this->buffered(i))
-  {
-    while(this->offset < i) { this->buffer.pop_front(); this->offset++; }
-  }
-  else
+  // Move the buffer and the file to the new position.
+  this->buffer.seek(i);
+  if(!(this->buffer.buffered(i)))
   {
     std::unique_lock<std::mutex> lock(this->mtx);
-    this->buffer.clear(); this->read_buffer.clear();
+    this->read_buffer.clear();
     this->file.seekg(i * sizeof(Element), std::ios_base::beg);
-    this->offset = this->file_offset = i;
+    this->file_offset = i;
   }
+
   if(this->buffer.size() < MINIMUM_SIZE)
   {
     std::unique_lock<std::mutex> lock(this->mtx);
@@ -606,10 +489,10 @@ void
 ReadBuffer<Element>::read(size_type i)
 {
   if(i >= this->size()) { return; }
-  if(i < this->offset) { this->seek(i); return; }
+  if(i < this->buffer.offset) { this->seek(i); return; }
 
   std::unique_lock<std::mutex> lock(this->mtx);
-  while(!(this->buffered(i))) { this->forceRead(); }
+  while(!(this->buffer.buffered(i))) { this->forceRead(); }
   this->empty.notify_one();
 }
 
@@ -624,7 +507,7 @@ ReadBuffer<Element>::forceRead()
     this->file_offset += this->read_buffer.size();
   }
 
-  this->buffer.insert(this->buffer.end(), this->read_buffer.begin(), this->read_buffer.end());
+  this->buffer.insert(this->read_buffer.begin(), this->read_buffer.end());
   this->read_buffer.clear();
 }
 
@@ -637,13 +520,18 @@ ReadBuffer<Element>::forceRead()
 template<class Element>
 struct WriteBuffer
 {
+  WriteBuffer();
   explicit WriteBuffer(const std::string& filename, size_type _buffer_size = MEGABYTE);
   ~WriteBuffer();
+
+  void open(const std::string& filename, size_type _buffer_size = MEGABYTE);
   void close();
+
+  inline size_type size() const { return this->elements; }
 
   inline void push_back(Element value)
   {
-    this->buffer.push_back(value);
+    this->buffer.push_back(value); this->elements++;
     if(buffer.size() >= this->buffer_size)
     {
       DiskIO::write(this->file, this->buffer.data(), this->buffer.size());
@@ -653,28 +541,43 @@ struct WriteBuffer
 
   std::ofstream        file;
   std::vector<Element> buffer;
-  size_type            buffer_size;
+  size_type            buffer_size, elements;
 
   WriteBuffer(const WriteBuffer&) = delete;
   WriteBuffer& operator= (const WriteBuffer&) = delete;
 };
 
 template<class Element>
-WriteBuffer<Element>::WriteBuffer(const std::string& filename, size_type _buffer_size) :
-  file(filename.c_str(), std::ios_base::binary), buffer(), buffer_size(_buffer_size)
+WriteBuffer<Element>::WriteBuffer() :
+  buffer_size(0), elements(0)
 {
-  if(!(this->file))
-  {
-    std::cerr << "WriteBuffer::WriteBuffer(): Cannot open output file " << filename << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-  this->buffer.reserve(this->buffer_size);
+}
+
+template<class Element>
+WriteBuffer<Element>::WriteBuffer(const std::string& filename, size_type _buffer_size)
+{
+  this->open(filename, _buffer_size);
 }
 
 template<class Element>
 WriteBuffer<Element>::~WriteBuffer()
 {
   this->close();
+}
+
+template<class Element>
+void
+WriteBuffer<Element>::open(const std::string& filename, size_type _buffer_size)
+{
+  this->file.open(filename.c_str(), std::ios_base::binary);
+  if(!(this->file))
+  {
+    std::cerr << "WriteBuffer::open(): Cannot open output file " << filename << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  this->buffer_size = _buffer_size; this->elements = 0;
+  this->buffer.reserve(this->buffer_size);
 }
 
 template<class Element>
@@ -687,6 +590,8 @@ WriteBuffer<Element>::close()
   }
   this->file.close();
   sdsl::util::clear(this->buffer);
+  this->buffer_size = 0;
+  this->elements = 0;
 }
 
 //------------------------------------------------------------------------------

--- a/internal.h
+++ b/internal.h
@@ -320,8 +320,11 @@ template<class Element>
 void
 BufferWindow<Element>::swap(BufferWindow<Element>& another)
 {
-  this->data.swap(another.data);
-  std::swap(this->offset, another.offset);
+  if(this != &another)
+  {
+    this->data.swap(another.data);
+    std::swap(this->offset, another.offset);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -32,15 +32,7 @@ namespace gcsa
 
 //------------------------------------------------------------------------------
 
-std::vector<PathNode::rank_type>
-PathNode::dummyRankVector()
-{
-  std::vector<rank_type> temp;
-  temp.reserve(LABEL_LENGTH + 1);
-  return temp;
-}
-
-PathNode::PathNode(const KMer& kmer, std::vector<PathNode::rank_type>& labels)
+PathNode::PathNode(const KMer& kmer, WriteBuffer<PathNode::rank_type>& labels)
 {
   this->from = kmer.from; this->to = kmer.to;
   this->fields = 0;
@@ -91,56 +83,10 @@ PathNode::PathNode(const PathNode& left, const PathNode& right,
   }
 }
 
-PathNode::PathNode(std::istream& in, std::vector<PathNode::rank_type>& labels)
-{
-  DiskIO::read(in, this);
-  this->setPointer(labels.size());
-
-  size_type old_size = labels.size();
-  labels.resize(old_size + this->ranks());
-  DiskIO::read(in, labels.data() + old_size, this->ranks());
-}
-
-PathNode::PathNode(std::istream& in, rank_type* labels)
-{
-  DiskIO::read(in, this);
-  this->setPointer(0);
-  DiskIO::read(in, labels, this->ranks());
-}
-
-void
-PathNode::serialize(std::ostream& out, const std::vector<rank_type>& labels) const
-{
-  DiskIO::write(out, this);
-  DiskIO::write(out, labels.data() + this->pointer(), this->ranks());
-}
-
-void
-PathNode::serialize(std::ostream& out, const rank_type* labels) const
-{
-  DiskIO::write(out, this);
-  DiskIO::write(out, labels + this->pointer(), this->ranks());
-}
-
-void
-PathNode::serialize(std::ostream& node_stream, std::ostream& label_stream, const rank_type* labels, size_type ptr)
-{
-  DiskIO::write(label_stream, labels + this->pointer(), this->ranks());
-  this->setPointer(ptr);
-  DiskIO::write(node_stream, this);
-}
-
 PathNode::PathNode()
 {
   this->from = 0; this->to = 0;
   this->fields = 0;
-}
-
-PathNode::PathNode(std::vector<rank_type>& labels)
-{
-  this->from = 0; this->to = 0;
-  this->fields = 0;
-  this->setPointer(labels.size());
 }
 
 PathNode::PathNode(const PathNode& source)
@@ -317,33 +263,7 @@ struct PriorityNode
     return (this->node.order() < another.node.order());
   }
 
-  inline void load(std::vector<std::ifstream>& files)
-  {
-    this->node = PathNode(files[this->file], this->label);
-    if(files[this->file].eof())
-    {
-      this->node.setOrder(1);
-      this->node.setLCP(1);
-      this->label[0] = NO_RANK;
-    }
-  }
-
   inline rank_type firstLabel(size_type i) const { return this->label[i]; }
-
-  inline void serialize(std::ostream& out) const
-  {
-    this->node.serialize(out, this->label);
-  }
-
-  inline void serialize(std::ostream& path_file, std::ostream& label_file, size_type ptr)
-  {
-    this->node.serialize(path_file, label_file, this->label, ptr);
-  }
-
-  inline void serialize(std::vector<std::ofstream>& files) const
-  {
-    this->node.serialize(files[this->file], this->label);
-  }
 
   inline size_type bytes() const { return this->node.bytes(); }
 };
@@ -358,7 +278,8 @@ struct PriorityNode
 struct PathGraphBuilder
 {
   PathGraph graph;
-  std::vector<std::ofstream> files;
+  std::vector<WriteBuffer<PathNode>> path_files;
+  std::vector<WriteBuffer<PathNode::rank_type>> rank_files;
   size_type limit;  // Bytes of disk space.
 
   const static size_type WRITE_BUFFER_SIZE = MEGABYTE;  // PathNodes per thread.
@@ -367,50 +288,61 @@ struct PathGraphBuilder
   void close();
 
   /*
-    The single write is not thread safe, while the batch write is. The file number is
-    assumed to be valid.
+    The file number is assumed to be valid.
+    The first call is not thread safe, while the bulk write() is.
   */
-  void write(const PriorityNode& path);
+  void write(PriorityNode& path);
   void write(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels, size_type file);
 
   void sort(size_type file);
 };
 
 PathGraphBuilder::PathGraphBuilder(size_type file_count, size_type path_order, size_type step, size_type size_limit) :
-  graph(file_count, path_order, step), files(file_count), limit(size_limit)
+  graph(file_count, path_order, step),
+  path_files(file_count), rank_files(file_count),
+  limit(size_limit)
 {
-  for(size_type file = 0; file < this->files.size(); file++)
+  for(size_type file = 0; file < file_count; file++)
   {
-    this->files[file].open(this->graph.filenames[file].c_str(), std::ios_base::binary);
-    if(!(this->files[file]))
-    {
-      std::cerr << "PathGraphBuilder::PathGraphBuilder(): Cannot open output file "
-                << this->graph.filenames[file] << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
+    this->path_files[file].open(this->graph.path_names[file]);
+    this->rank_files[file].open(this->graph.rank_names[file]);
   }
 }
 
 void
 PathGraphBuilder::close()
 {
-  for(size_type file = 0; file < this->files.size(); file++)
+  for(size_type file = 0; file < this->path_files.size(); file++)
   {
-    this->files[file].close();
+    this->path_files[file].close();
+    this->rank_files[file].close();
   }
 }
 
-void
-PathGraphBuilder::write(const PriorityNode& path)
+inline void
+writePath(PathNode& path, const PathNode::rank_type* labels,
+  WriteBuffer<PathNode>& path_file, WriteBuffer<PathNode::rank_type>& rank_file)
 {
-  if(this->graph.bytes() + path.bytes() > limit)
+  size_type old_ptr = path.pointer();
+  size_type limit = old_ptr + path.ranks();
+
+  path.setPointer(rank_file.size());
+  path_file.push_back(path);
+
+  for(size_type i = old_ptr; i < limit; i++) { rank_file.push_back(labels[i]); }
+}
+
+void
+PathGraphBuilder::write(PriorityNode& path)
+{
+  if(this->graph.bytes() + path.bytes() > this->limit)
   {
     std::cerr << "PathGraphBuilder::write(): Size limit exceeded, construction aborted" << std::endl;
     std::exit(EXIT_FAILURE);
   }
+  writePath(path.node, path.label, this->path_files[path.file], this->rank_files[path.file]);
 
-  path.serialize(this->files);
-  this->graph.sizes[path.file]++; this->graph.path_count++;
+  this->graph.path_counts[path.file]++; this->graph.path_count++;
   this->graph.rank_counts[path.file] += path.node.ranks();
   this->graph.rank_count += path.node.ranks();
 }
@@ -421,13 +353,16 @@ PathGraphBuilder::write(std::vector<PathNode>& paths, std::vector<PathNode::rank
   size_type bytes_required = paths.size() * sizeof(PathNode) + labels.size() * sizeof(PathNode::rank_type);
   #pragma omp critical
   {
-    if(bytes_required + this->graph.bytes() > limit)
+    if(bytes_required + this->graph.bytes() > this->limit)
     {
       std::cerr << "PathGraphBuilder::write(): Size limit exceeded, construction aborted" << std::endl;
       std::exit(EXIT_FAILURE);
     }
-    for(auto& path : paths) { path.serialize(this->files[file], labels); }
-    this->graph.sizes[file] += paths.size(); this->graph.path_count += paths.size();
+    for(size_type i = 0; i < paths.size(); i++)
+    {
+      writePath(paths[i], labels.data(), this->path_files[file], this->rank_files[file]);
+    }
+    this->graph.path_counts[file] += paths.size(); this->graph.path_count += paths.size();
     this->graph.rank_counts[file] += labels.size(); this->graph.rank_count += labels.size();
   }
   paths.clear(); labels.clear();
@@ -436,7 +371,8 @@ PathGraphBuilder::write(std::vector<PathNode>& paths, std::vector<PathNode::rank
 void
 PathGraphBuilder::sort(size_type file)
 {
-  this->files[file].close();
+  this->path_files[file].close();
+  this->rank_files[file].close();
 
   std::vector<PathNode> paths;
   std::vector<PathNode::rank_type> labels;
@@ -445,116 +381,18 @@ PathGraphBuilder::sort(size_type file)
   PathFirstComparator first_c(labels);
   parallelQuickSort(paths.begin(), paths.end(), first_c);
 
-  this->files[file].open(this->graph.filenames[file].c_str(), std::ios_base::binary);
-  for(auto& path : paths) { path.serialize(this->files[file], labels); }
+  this->path_files[file].open(this->graph.path_names[file]);
+  this->rank_files[file].open(this->graph.rank_names[file]);
+  for(size_type i = 0; i < paths.size(); i++)
+  {
+    writePath(paths[i], labels.data(), this->path_files[file], this->rank_files[file]);
+  }
 
   if(Verbosity::level >= Verbosity::FULL)
   {
     std::cerr << "PathGraphBuilder::sort(): File " << file << ": Sorted "
-              << this->graph.sizes[file] << " paths" << std::endl;
+              << this->graph.path_counts[file] << " paths" << std::endl;
   }
-}
-
-//------------------------------------------------------------------------------
-
-/*
-  This Reader reads PathNodes and their labels from a PathGraph, merging them into a
-  single sorted stream of PriorityNodes.
-*/
-
-struct PriorityNodeReader
-{
-  PriorityNodeReader() : files(0), inputs(0), elements(0) { }
-  ~PriorityNodeReader() { this->close(); }
-
-  void init(const PathGraph& graph);
-  void close();
-
-  inline size_type size() const { return this->elements; }
-  void append(std::deque<PriorityNode>& buffer, size_type n, std::vector<PriorityNode>& read_buffer);
-  void read(std::vector<PriorityNode>& read_buffer);
-  void seek(size_type i);
-  void finish() { this->offset = this->size(); }
-  bool finished() { return (this->offset >= this->size()); }
-
-  inline void next()
-  {
-    this->inputs[0].load(this->files);
-    this->inputs.down(0);
-  }
-
-  std::vector<std::ifstream>  files;
-  PriorityQueue<PriorityNode> inputs;
-  size_type                   elements, offset;
-
-  PriorityNodeReader(const PriorityNodeReader&) = delete;
-  PriorityNodeReader& operator= (const PriorityNodeReader&) = delete;
-};
-
-void
-PriorityNodeReader::init(const PathGraph& graph)
-{
-  if(this->files.size() != 0)
-  {
-    std::cerr << "PriorityNodeReader::init(): The reader is already initialized" << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-
-  this->elements = graph.size(); this->offset = 0;
-  this->files = std::vector<std::ifstream>(graph.files());
-  this->inputs.resize(graph.files());
-  for(size_type file = 0; file < this->files.size(); file++)
-  {
-    graph.open(this->files[file], file);
-    this->inputs[file].file = file;
-    this->inputs[file].load(this->files);
-  }
-  this->inputs.heapify();
-}
-
-void
-PriorityNodeReader::close()
-{
-  for(size_type file = 0; file < this->files.size(); file++)
-  {
-    this->files[file].close();
-  }
-  this->elements = 0;
-}
-
-void
-PriorityNodeReader::append(std::deque<PriorityNode>& buffer, size_type n, std::vector<PriorityNode>&)
-{
-  n = std::min(this->size() - this->offset, n);
-  while(n > 0)
-  {
-    buffer.push_back(this->inputs[0]); n--;
-    this->next(); this->offset++;
-  }
-}
-
-void
-PriorityNodeReader::read(std::vector<PriorityNode>& read_buffer)
-{
-  if(read_buffer.size() > this->size() - this->offset) { read_buffer.resize(this->size() - this->offset); }
-  for(size_type i = 0; i < read_buffer.size(); i++)
-  {
-    read_buffer[i] = this->inputs[0];
-    this->next(); this->offset++;
-  }
-}
-
-void
-PriorityNodeReader::seek(size_type i)
-{
-  if(i > this->size()) { i = this->size(); }
-  if(i < this->offset)
-  {
-    std::cerr << "PriorityNodeReader::seek(): Cannot seek backwards" << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-
-  while(this->offset < i) { this->next(); this->offset++; }
 }
 
 //------------------------------------------------------------------------------
@@ -579,11 +417,19 @@ struct PathRange
 
 struct PathGraphMerger
 {
-  const PathGraph&                             graph;
-  const LCP&                                   lcp;
-  OldReadBuffer<PriorityNode, PriorityNodeReader> buffer;
-  std::deque<PathRange>                        ranges;
-  bool                                         need_range_lcp;
+  const PathGraph&                              graph;
+  const LCP&                                    lcp;
+  bool                                          need_range_lcp;
+
+  // Buffers.
+  std::deque<PathRange>                         ranges;
+  BufferWindow<PriorityNode>                    buffer;
+
+  // Priority queue.
+  std::vector<ReadBuffer<PathNode>>             path_files;
+  std::vector<ReadBuffer<PathNode::rank_type>>  rank_files;
+  std::vector<size_type>                        offsets;
+  PriorityQueue<PriorityNode>                   inputs;
 
   PathGraphMerger(const PathGraph& path_graph, const LCP& _lcp, bool set_range_lcp);
   void close();
@@ -591,25 +437,17 @@ struct PathGraphMerger
   inline size_type size() const { return this->graph.size(); }
 
   /*
-    Iterates through ranges of paths with the same label. The ranges are buffered in
-    a deque.
+    Iterates through ranges of paths with the same label.
   */
   range_type first();
   range_type next();
   inline bool atEnd(range_type range) const { return (range.first >= this->size()); }
 
-  inline size_type rangeEnd(size_type start)
-  {
-    size_type stop = start;
-    while(stop + 1 < this->size() && !(this->buffer[start] < this->buffer[stop + 1])) { stop++; }
-    return stop;
-  }
-
   /*
     Each file must have its own source/sink nodes, even though they might share their
     labels. Hence we check for the file number here.
   */
-  inline bool sameFrom(size_type i, size_type j)
+  inline bool sameFrom(size_type i, size_type j) const
   {
     return (this->buffer[i].node.from == this->buffer[j].node.from &&
             this->buffer[i].file == this->buffer[j].file);
@@ -618,13 +456,13 @@ struct PathGraphMerger
   bool sameFrom(range_type range);
   inline bool sameFrom(const PathRange& range) { return this->sameFrom(range.range()); }
 
-  inline range_type range_lcp(size_type i, size_type j) // i < j
+  inline range_type range_lcp(size_type i, size_type j) const // i < j
   {
     return this->lcp.min_lcp(this->buffer[i].node, this->buffer[j].node,
       this->buffer[i].label, this->buffer[j].label);
   }
 
-  inline range_type border_lcp(size_type i, size_type j) // i < j
+  inline range_type border_lcp(size_type i, size_type j) const // i < j
   {
     return this->lcp.max_lcp(this->buffer[i].node, this->buffer[j].node,
       this->buffer[i].label, this->buffer[j].label);
@@ -649,19 +487,47 @@ struct PathGraphMerger
   */
   void mergePathNodes();
   void mergePathNodes(range_type range, std::vector<range_type>& from_nodes, size_type path_id);
+
+  // Find the rightmost path with the same label.
+  size_type rangeEnd(size_type start);
+
+  // Add the next PriorityNode to buffer.
+  void bufferNext();
+
+  // Read the next PriorityNode from the file.
+  void read(PriorityNode& path);
 };
 
 PathGraphMerger::PathGraphMerger(const PathGraph& path_graph, const LCP& _lcp, bool set_range_lcp) :
-  graph(path_graph), lcp(_lcp), need_range_lcp(set_range_lcp)
+  graph(path_graph), lcp(_lcp), need_range_lcp(set_range_lcp),
+  path_files(path_graph.files()), rank_files(path_graph.files()),
+  offsets(path_graph.files()), inputs(path_graph.files())
 {
-  this->buffer.init(std::ref(this->graph));
+  for(size_type file = 0; file < path_graph.files(); file++)
+  {
+    this->path_files[file].open(path_graph.path_names[file]);
+    this->rank_files[file].open(path_graph.rank_names[file]);
+    this->offsets[file] = 0;
+    this->inputs[file].file = file; this->read(this->inputs[file]);
+  }
+  this->inputs.heapify();
 }
 
 void
 PathGraphMerger::close()
 {
-  this->buffer.close();
-  this->ranges.clear();
+  sdsl::util::clear(this->ranges);
+  sdsl::util::clear(this->buffer);
+
+  for(size_type file = 0; file < this->graph.files(); file++)
+  {
+    this->path_files[file].close();
+    this->rank_files[file].close();
+  }
+  this->path_files.clear();
+  this->rank_files.clear();
+  this->offsets.clear();
+  this->inputs.clear();
 }
 
 range_type
@@ -782,6 +648,52 @@ PathGraphMerger::mergePathNodes(range_type range, std::vector<range_type>& from_
   removeDuplicates(from_nodes, false);
 }
 
+size_type
+PathGraphMerger::rangeEnd(size_type start)
+{
+  if(!(this->buffer.buffered(start))) { this->bufferNext(); }
+
+  size_type stop = start;
+  while(stop + 1 < this->size())
+  {
+    if(!(this->buffer.buffered(stop + 1))) { this->bufferNext(); }
+    if(this->buffer[start] < this->buffer[stop + 1]) { break; }
+    stop++;
+  }
+  return stop;
+}
+
+void
+PathGraphMerger::bufferNext()
+{
+  this->buffer.push_back(this->inputs[0]);  // Add to the buffer.
+  this->read(this->inputs[0]);  // Read the next.
+  this->inputs.down(0); // Restore heap order.
+}
+
+void
+PathGraphMerger::read(PriorityNode& path)
+{
+  if(this->offsets[path.file] >= this->graph.path_counts[path.file])
+  {
+    path.node.setOrder(1);
+    path.node.setLCP(1);
+    path.label[0] = PriorityNode::NO_RANK;
+  }
+  else
+  {
+    this->path_files[path.file].seek(this->offsets[path.file]);
+    path.node = this->path_files[path.file][this->offsets[path.file]];
+    this->rank_files[path.file].seek(path.node.pointer());
+    for(size_type i = 0; i < path.node.ranks(); i++)
+    {
+      path.label[i] = this->rank_files[path.file][path.node.pointer() + i];
+    }
+    path.node.setPointer(0);  // Label is now stored in the PriorityNode.
+    this->offsets[path.file]++;
+  }
+}
+
 PathRange::PathRange(size_type start, size_type stop, range_type _left_lcp, PathGraphMerger& merger) :
   from(start), to(stop),
   left_lcp(_left_lcp),
@@ -805,17 +717,10 @@ PathGraph::PathGraph(const InputGraph& source, sdsl::sd_vector<>& key_exists)
   sdsl::sd_vector<>::rank_1_type key_rank(&key_exists);
   for(size_type file = 0; file < source.files(); file++)
   {
-    std::string temp_file = TempFile::getName(PREFIX);
-    this->filenames.push_back(temp_file);
-    this->sizes.push_back(source.sizes[file]); this->path_count += source.sizes[file];
-    this->rank_counts.push_back(2 * source.sizes[file]); this->rank_count += 2 * source.sizes[file];
-
-    std::ofstream out(temp_file.c_str(), std::ios_base::binary);
-    if(!out)
-    {
-      std::cerr << "PathGraph::PathGraph(): Cannot open output file " << temp_file << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
+    std::string path_name = TempFile::getName(PREFIX);
+    this->path_names.push_back(path_name);
+    std::string rank_name = TempFile::getName(PREFIX);
+    this->rank_names.push_back(rank_name);
 
     // Read KMers, sort them, and convert the keys labels to the ranks of those labels.
     std::vector<KMer> kmers;
@@ -828,14 +733,15 @@ PathGraph::PathGraph(const InputGraph& source, sdsl::sd_vector<>& key_exists)
     }
 
     // Convert the KMers to PathNodes.
-    std::vector<PathNode::rank_type> temp_labels = PathNode::dummyRankVector();
+    WriteBuffer<PathNode> path_buffer(path_name);
+    WriteBuffer<PathNode::rank_type> rank_buffer(rank_name);
     for(size_type i = 0; i < kmers.size(); i++)
     {
-      PathNode temp(kmers[i], temp_labels);
-      temp.serialize(out, temp_labels);
-      temp_labels.resize(0);
+      path_buffer.push_back(PathNode(kmers[i], rank_buffer));
     }
-    out.close();
+    this->path_counts.push_back(path_buffer.size()); this->path_count += path_buffer.size();
+    this->rank_counts.push_back(rank_buffer.size()); this->rank_count += rank_buffer.size();
+    path_buffer.close(); rank_buffer.close();
   }
 
   if(Verbosity::level >= Verbosity::EXTENDED)
@@ -848,13 +754,14 @@ PathGraph::PathGraph(const InputGraph& source, sdsl::sd_vector<>& key_exists)
 }
 
 PathGraph::PathGraph(size_type file_count, size_type path_order, size_type steps) :
-  filenames(file_count), sizes(file_count, 0), rank_counts(file_count, 0),
+  path_names(file_count), rank_names(file_count), path_counts(file_count, 0), rank_counts(file_count, 0),
   path_count(0), rank_count(0), range_count(0), order(path_order), doubling_steps(steps),
   unique(0), unsorted(0), nondeterministic(0)
 {
   for(size_type file = 0; file < this->files(); file++)
   {
-    this->filenames[file] = TempFile::getName(PREFIX);
+    this->path_names[file] = TempFile::getName(PREFIX);
+    this->rank_names[file] = TempFile::getName(PREFIX);
   }
 }
 
@@ -868,10 +775,12 @@ PathGraph::clear()
 {
   for(size_type file = 0; file < this->files(); file++)
   {
-    TempFile::remove(this->filenames[file]);
+    TempFile::remove(this->path_names[file]);
+    TempFile::remove(this->rank_names[file]);
   }
-  this->filenames.clear();
-  this->sizes.clear();
+  this->path_names.clear();
+  this->rank_names.clear();
+  this->path_counts.clear();
   this->rank_counts.clear();
 
   this->path_count = 0; this->rank_count = 0;
@@ -882,8 +791,9 @@ PathGraph::clear()
 void
 PathGraph::swap(PathGraph& another)
 {
-  this->filenames.swap(another.filenames);
-  this->sizes.swap(another.sizes);
+  this->path_names.swap(another.path_names);
+  this->rank_names.swap(another.rank_names);
+  this->path_counts.swap(another.path_counts);
   this->rank_counts.swap(another.rank_counts);
 
   std::swap(this->path_count, another.path_count);
@@ -898,7 +808,7 @@ PathGraph::swap(PathGraph& another)
 }
 
 void
-PathGraph::open(std::ifstream& input, size_type file) const
+PathGraph::open(std::ifstream& path_file, std::ifstream& rank_file, size_type file) const
 {
   if(file >= this->files())
   {
@@ -906,10 +816,17 @@ PathGraph::open(std::ifstream& input, size_type file) const
     std::exit(EXIT_FAILURE);
   }
 
-  input.open(this->filenames[file].c_str(), std::ios_base::binary);
-  if(!input)
+  path_file.open(this->path_names[file].c_str(), std::ios_base::binary);
+  if(!path_file)
   {
-    std::cerr << "PathGraph::open(): Cannot open graph file " << this->filenames[file] << std::endl;
+    std::cerr << "PathGraph::open(): Cannot open path file " << this->path_names[file] << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  rank_file.open(this->rank_names[file].c_str(), std::ios_base::binary);
+  if(!rank_file)
+  {
+    std::cerr << "PathGraph::open(): Cannot open rank file " << this->rank_names[file] << std::endl;
     std::exit(EXIT_FAILURE);
   }
 }
@@ -1021,7 +938,7 @@ PathGraph::extend(size_type size_limit)
 
     if(Verbosity::level >= Verbosity::FULL)
     {
-      std::cerr << "PathGraph::extend(): File " << file << ": Created " << builder.graph.sizes[file]
+      std::cerr << "PathGraph::extend(): File " << file << ": Created " << builder.graph.path_counts[file]
                 << " order-" << builder.graph.k() << " paths" << std::endl;
     }
 
@@ -1045,12 +962,14 @@ PathGraph::extend(size_type size_limit)
 void
 PathGraph::read(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& labels, size_type file) const
 {
-  sdsl::util::clear(paths); sdsl::util::clear(labels);
+  paths.resize(this->path_counts[file]);
+  labels.resize(this->rank_counts[file]);
 
-  std::ifstream input; this->open(input, file);
-  paths.reserve(this->sizes[file]); labels.reserve(this->rank_counts[file]);
-  for(size_type i = 0; i < this->sizes[file]; i++) { paths.push_back(PathNode(input, labels)); }
-  input.close();
+  std::ifstream path_file, rank_file;
+  this->open(path_file, rank_file, file);
+  DiskIO::read(path_file, paths.data(), this->path_counts[file]);
+  DiskIO::read(rank_file, labels.data(), this->rank_counts[file]);
+  path_file.close(); rank_file.close();
 
   if(Verbosity::level >= Verbosity::FULL)
   {
@@ -1070,25 +989,10 @@ MergedGraph::MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, c
   order(source.k()),
   next(mapper.alpha.sigma + 1, 0), next_from(mapper.alpha.sigma + 1, 0)
 {
-  std::ofstream path_file(this->path_name.c_str(), std::ios_base::binary);
-  if(!path_file)
-  {
-    std::cerr << "MergedGraph::MergedGraph(): Cannot open output file " << this->path_name << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-  std::ofstream rank_file(this->rank_name.c_str(), std::ios_base::binary);
-  if(!rank_file)
-  {
-    std::cerr << "MergedGraph::MergedGraph(): Cannot open output file " << this->rank_name << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-  std::ofstream from_file(this->from_name.c_str(), std::ios_base::binary);
-  if(!from_file)
-  {
-    std::cerr << "MergedGraph::MergedGraph(): Cannot open output file " << this->from_name << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
-  WriteBuffer<uint8_t> lcp_array(this->lcp_name);
+  WriteBuffer<PathNode>            path_file(this->path_name);
+  WriteBuffer<PathNode::rank_type> rank_file(this->rank_name);
+  WriteBuffer<range_type>          from_file(this->from_name);
+  WriteBuffer<uint8_t>             lcp_file(this->lcp_name);
 
   /*
      Initialize next[comp] to be the the rank of the first kmer starting with
@@ -1108,12 +1012,12 @@ MergedGraph::MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, c
   for(range_type range = merger.first(); !(merger.atEnd(range)); range = merger.next())
   {
     range_type path_lcp = merger.ranges.front().left_lcp;
-    lcp_array.push_back(path_lcp.first * mapper.order() + path_lcp.second);
+    lcp_file.push_back(path_lcp.first * mapper.order() + path_lcp.second);
     merger.mergePathNodes(range, curr_from, this->path_count);
-    merger.buffer[range.second].serialize(path_file, rank_file, this->rank_count);
+    writePath(merger.buffer[range.second].node, merger.buffer[range.second].label, path_file, rank_file);
     if(curr_from.size() > 0)
     {
-      DiskIO::write(from_file, curr_from.data(), curr_from.size());
+      for(size_type i = 0; i < curr_from.size(); i++) { from_file.push_back(curr_from[i]); }
     }
     while(merger.buffer[range.second].firstLabel(0) >= this->next[curr_comp])
     {
@@ -1126,7 +1030,7 @@ MergedGraph::MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, c
     this->from_count += curr_from.size();
   }
   merger.close();
-  path_file.close(); rank_file.close(); from_file.close(); lcp_array.close();
+  path_file.close(); rank_file.close(); from_file.close(); lcp_file.close();
 
   if(Verbosity::level >= Verbosity::EXTENDED)
   {

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -581,7 +581,7 @@ struct PathGraphMerger
 {
   const PathGraph&                             graph;
   const LCP&                                   lcp;
-  ReadBuffer<PriorityNode, PriorityNodeReader> buffer;
+  OldReadBuffer<PriorityNode, PriorityNodeReader> buffer;
   std::deque<PathRange>                        ranges;
   bool                                         need_range_lcp;
 


### PR DESCRIPTION
Disk I/O simplifications to make future changes to index construction easier.
- The optional `Alphabet` object is now passed to `InputGraph` instead of `GCSA` during construction.
- Temporary files are always written using `WriteBuffer` objects.
- Temporary files are always read using `ReadBuffer` objects or with a single `DiskIO::read()` call.
- The construction of a whole-genome index seems to take an hour or two less than before.
