### PR TITLE
Changes necessary to build with clang-omp on Mac 10.10.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SDSL_DIR=../sdsl-lite
 #VERIFY_FLAGS=-DVERIFY_CONSTRUCTION
 
 # Multithreading with OpenMP and libstdc++ Parallel Mode.
-PARALLEL_FLAGS=-fopenmp -pthread -D_GLIBCXX_PARALLEL
+PARALLEL_FLAGS=-fopenmp -pthread
 
 # Verbose output during index construction etc.
 OUTPUT_FLAGS=-DVERBOSE_STATUS_INFO

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ SDSL_DIR=../sdsl-lite
 
 # Multithreading with OpenMP and libstdc++ Parallel Mode.
 PARALLEL_FLAGS=-fopenmp -pthread
+# Turn off libstdc++ parallel mode for clang
+ifneq (clang,$(findstring clang,$(shell $(CXX) --version)))
+PARALLEL_FLAGS+=-D_GLIBCXX_PARALLEL
+endif
 
 # Verbose output during index construction etc.
 OUTPUT_FLAGS=-DVERBOSE_STATUS_INFO

--- a/algorithms.cpp
+++ b/algorithms.cpp
@@ -322,7 +322,8 @@ countKMers(const GCSA& index, size_type k, bool force)
     {
       node_stack.push(ReverseTrieNode(index.charRange(comp), 1, false));
     }
-    SeedCollector collector(std::min(k, ReverseTrieNode::SEED_LENGTH));
+    size_type seed_length = ReverseTrieNode::SEED_LENGTH;  // avoid direct use of static const
+    SeedCollector collector(std::min(k, seed_length));
     processSubtree(index, node_stack, collector);
     result = collector.count;
     seeds = collector.seeds;

--- a/files.cpp
+++ b/files.cpp
@@ -207,7 +207,8 @@ range_type
 parseKMer(const std::string& kmer_line)
 {
   std::string extensions;
-  range_type result(InputGraph::UNKNOWN, 0);
+  size_type unknown = InputGraph::UNKNOWN;  // avoid direct use of static const
+  range_type result(unknown, 0);
   {
     std::string token;
     std::istringstream ss(kmer_line);

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -360,9 +360,10 @@ inline PathLabel
 firstLabel(const PathNode& path, ReadBuffer<PathNode::rank_type>& labels)
 {
   PathLabel res; res.first = true;
-  size_type limit = std::min(path.order(), PathLabel::LABEL_LENGTH);
+  size_type label_length = PathLabel::LABEL_LENGTH;  // avoid direct use of static const
+  size_type limit = std::min(path.order(), label_length);
   for(size_type i = 0; i < limit; i++) { res.label[i] = path.firstLabel(i, labels); }
-  for(size_type i = limit; i < PathLabel::LABEL_LENGTH; i++) { res.label[i] = 0; }
+  for(size_type i = limit; i < label_length; i++) { res.label[i] = 0; }
   return res;
 }
 
@@ -370,9 +371,10 @@ inline PathLabel
 lastLabel(const PathNode& path, ReadBuffer<PathNode::rank_type>& labels)
 {
   PathLabel res; res.first = false;
-  size_type limit = std::min(path.order(), PathLabel::LABEL_LENGTH);
+  size_type label_length = PathLabel::LABEL_LENGTH;  // avoid direct use of static const
+  size_type limit = std::min(path.order(), label_length);
   for(size_type i = 0; i < limit; i++) { res.label[i] = path.lastLabel(i, labels); }
-  for(size_type i = limit; i < PathLabel::LABEL_LENGTH; i++) { res.label[i] = PathLabel::NO_RANK; }
+  for(size_type i = limit; i < label_length; i++) { res.label[i] = PathLabel::NO_RANK; }
   return res;
 }
 

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -980,8 +980,8 @@ PathGraph::extend(size_type size_limit)
     size_type threads = omp_get_max_threads();
 
     // Create thread-specific buffers.
-    std::vector<PathNode> temp_nodes[threads];
-    std::vector<PathNode::rank_type> temp_labels[threads];
+    std::vector<std::vector<PathNode>> temp_nodes(threads);
+    std::vector<std::vector<PathNode::rank_type>> temp_labels(threads);
     for(size_type thread = 0; thread < threads; thread++)
     {
       temp_nodes[thread].reserve(PathGraphBuilder::WRITE_BUFFER_SIZE);

--- a/support.cpp
+++ b/support.cpp
@@ -372,7 +372,8 @@ std::string
 Key::decode(key_type key, size_type kmer_length, const Alphabet& alpha)
 {
   key = label(key);
-  kmer_length = std::min(kmer_length, MAX_LENGTH);
+  size_type max_length = Key::MAX_LENGTH;  // avoid direct use of static const
+  kmer_length = std::min(kmer_length, max_length);
 
   std::string res(kmer_length, '\0');
   for(size_type i = 1; i <= kmer_length; i++)


### PR DESCRIPTION
Fixes the following build issues encountered:

Undeclared __gnu_parallel:

```
In file included from algorithms.cpp:27:
In file included from ./algorithms.h:28:
In file included from ./gcsa.h:28:
In file included from ./files.h:28:
In file included from ./support.h:28:
./utils.h:221:32: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, comp, __gnu_parallel::balanced_quicksort_tag());
                               ^
./utils.h:235:26: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, __gnu_parallel::balanced_quicksort_tag());
                         ^
./utils.h:247:32: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, comp, __gnu_parallel::multiway_mergesort_tag());
                               ^
./utils.h:258:26: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, __gnu_parallel::multiway_mergesort_tag());
                         ^
./utils.h:269:32: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, comp, __gnu_parallel::sequential_tag());
                               ^
./utils.h:280:26: error: use of undeclared identifier '__gnu_parallel'
  std::sort(first, last, __gnu_parallel::sequential_tag());
                         ^
6 errors generated.
make[1]: *** [algorithms.o] Error 1
make: *** [lib/libgcsa2.a] Error 2
```

Undefined symbols because of direct use of static const (when passing by const reference):

```
Undefined symbols for architecture x86_64:
  "__ZN4gcsa10InputGraph7UNKNOWNE", referenced from:
      __ZN4gcsa9parseKMerERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE in libgcsa2.a(files.o)
  "__ZN4gcsa15ReverseTrieNode11SEED_LENGTHE", referenced from:
      __ZN4gcsa10countKMersERKNS_4GCSAEyb in libgcsa2.a(algorithms.o)
  "__ZN4gcsa3Key10MAX_LENGTHE", referenced from:
      __ZN4gcsa3Key6decodeEyyRKNS_8AlphabetE in libgcsa2.a(support.o)
  "__ZN4gcsa9PathLabel12LABEL_LENGTHE", referenced from:
      __ZN4gcsa17MergedGraphReader9intersectERKNS_9PathLabelES3_y in libgcsa2.a(gcsa.o)
ld: symbol(s) not found for architecture x86_64
```

http://stackoverflow.com/questions/5391973/undefined-reference-to-static-const-int
http://stackoverflow.com/questions/2605520/c-where-to-initialize-static-const
