### PR TITLE
Fix clang compilation errors

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -393,7 +393,8 @@ template<class Element>
 ReadBuffer<Element>::ReadBuffer()
 {
   this->elements = 0; this->file_offset = 0;
-  this->read_buffer.reserve(READ_BUFFER_SIZE);
+  size_type buffer_size = READ_BUFFER_SIZE;  // avoid direct use
+  this->read_buffer.reserve(buffer_size);
 }
 
 template<class Element>
@@ -480,7 +481,8 @@ ReadBuffer<Element>::fill()
   std::unique_lock<std::mutex> lock(this->mtx);
   this->empty.wait(lock, [this]() { return read_buffer.empty(); } );
 
-  this->read_buffer.resize(std::min(READ_BUFFER_SIZE, this->size() - this->file_offset));
+  size_type read_buffer_size = READ_BUFFER_SIZE;  // avoid direct use
+  this->read_buffer.resize(std::min(read_buffer_size, this->size() - this->file_offset));
   DiskIO::read(this->file, this->read_buffer.data(), this->read_buffer.size());
   this->file_offset += this->read_buffer.size();
 
@@ -505,7 +507,8 @@ ReadBuffer<Element>::forceRead()
 {
   if(this->read_buffer.empty())
   {
-    this->read_buffer.resize(std::min(READ_BUFFER_SIZE, this->size() - this->file_offset));
+    size_type read_buffer_size = READ_BUFFER_SIZE;  // avoid direct use
+    this->read_buffer.resize(std::min(read_buffer_size, this->size() - this->file_offset));
     DiskIO::read(this->file, this->read_buffer.data(), this->read_buffer.size());
     this->file_offset += this->read_buffer.size();
   }


### PR DESCRIPTION
Fixes clang compilation errors on Mac OSX due to undefined static const references:

```
Undefined symbols for architecture x86_64:
  "__ZN4gcsa10ReadBufferINS_8PathNodeEE16READ_BUFFER_SIZEE", referenced from:
     __ZN4gcsa10ReadBufferINS_8PathNodeEE9forceReadEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferINS_8PathNodeEE4fillEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferINS_8PathNodeEE9forceReadEv in libgcsa2.a(path_graph.o)
     __ZN4gcsa10ReadBufferINS_8PathNodeEE4fillEv in libgcsa2.a(path_graph.o)
  "__ZN4gcsa10ReadBufferINSt3__14pairIyyEEE16READ_BUFFER_SIZEE", referenced from:
     __ZN4gcsa10ReadBufferINSt3__14pairIyyEEE9forceReadEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferINSt3__14pairIyyEEE4fillEv in libgcsa2.a(gcsa.o)
  "__ZN4gcsa10ReadBufferIhE16READ_BUFFER_SIZEE", referenced from:
     __ZN4gcsa10ReadBufferIhE9forceReadEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferIhE4fillEv in libgcsa2.a(gcsa.o)
  "__ZN4gcsa10ReadBufferIjE16READ_BUFFER_SIZEE", referenced from:
     __ZN4gcsa10ReadBufferIjE9forceReadEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferIjE4fillEv in libgcsa2.a(gcsa.o)
     __ZN4gcsa10ReadBufferIjE9forceReadEv in libgcsa2.a(path_graph.o)
     __ZN4gcsa10ReadBufferIjE4fillEv in libgcsa2.a(path_graph.o)
ld: symbol(s) not found for architecture x86_64
clang-3.5: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/vg] Error 1
```
