### PR TITLE
Maximal pruning

### DIFF
--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -465,7 +465,6 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters)
   {
     std::cerr << "GCSA::GCSA(): Prefix-doubling from path length " << path_graph.k() << std::endl;
   }
-  bool fully_sorted = false;
   for(size_type step = 1; step <= parameters.doubling_steps; step++)
   {
     if(Verbosity::level >= Verbosity::BASIC)
@@ -474,7 +473,6 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters)
                 << (2 * path_graph.k()) << ")" << std::endl;
     }
     path_graph.prune(lcp, parameters.size_limit);
-    if(path_graph.unsorted == 0) { fully_sorted = true; break; }
     path_graph.extend(parameters.size_limit);
   }
   if(Verbosity::level >= Verbosity::EXTENDED)
@@ -490,14 +488,9 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters)
   {
     std::cerr << "GCSA::GCSA(): Merging the paths" << std::endl;
   }
-  if(!fully_sorted) // This is not strictly necessary, but prune() makes the following merge() faster.
-  {
-    path_graph.prune(lcp, parameters.size_limit);
-    if(path_graph.unsorted == 0) { fully_sorted = true; }
-  }
   MergedGraph merged_graph(path_graph, mapper, lcp, parameters.size_limit);
   this->header.path_nodes = merged_graph.size();
-  this->header.order = (fully_sorted ? ~(size_type)0 : path_graph.k());
+  this->header.order = merged_graph.k();
   path_graph.clear();
   sdsl::util::clear(lcp);
   if(Verbosity::level >= Verbosity::EXTENDED)

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -985,7 +985,14 @@ struct SameFromSet
   inline bool operator() (range_type range)
   {
     this->fromNodes(range, this->buffer);
-    return (this->buffer == this->nodes);
+
+    // Manual comparison guarantees using a single thread.
+    if(this->buffer.size() != this->nodes.size()) { return false; }
+    for(size_type i = 0; i < this->buffer.size(); i++)
+    {
+      if(this->buffer[i] != this->nodes[i]) { return false; }
+    }
+    return true;
   }
 
   inline void select(range_type range)


### PR DESCRIPTION
Faster construction that produces slightly smaller indexes. The indexes are now based on maximally pruned de Bruijn graphs, which are more intuitive than the non-maximally pruned graphs used earlier.
