### PR TITLE
Multiple layers

### DIFF
--- a/files.cpp
+++ b/files.cpp
@@ -233,16 +233,14 @@ parseKMer(const std::string& kmer_line)
 /*
   If the kmer ends with an endmarker, it cannot be extended, and we mark it
   sorted. If its label is not unique, it will be treated as a nondeterministic
-  path. We also mark nodes ending with the source marker sorted, because there
-  should be only one such path, which is duplicated in each input file.
+  path.
 */
 void
 markSourceSinkNodes(std::vector<KMer>& kmers)
 {
   for(size_type i = 0; i < kmers.size(); i++)
   {
-    if(Key::last(kmers[i].key) == Alphabet::SOURCE_COMP ||
-       Key::last(kmers[i].key) == Alphabet::SINK_COMP)
+    if(Key::last(kmers[i].key) == Alphabet::SINK_COMP)
     {
       kmers[i].makeSorted();
     }

--- a/path_graph.h
+++ b/path_graph.h
@@ -297,7 +297,7 @@ struct PathGraph
   size_type path_count, rank_count, range_count;
   size_type order, doubling_steps;
 
-  size_type unique, unsorted, nondeterministic;
+  size_type unique, redundant, unsorted, nondeterministic;
 
   const static size_type UNKNOWN = ~(size_type)0;
   const static std::string PREFIX;  // .gcsa


### PR DESCRIPTION
Index multiple subgraphs (e.g. a pruned variation graph and the reference path) in a single GCSA2 index. Paths will not cross from one subgraph to another during prefix-doubling (`prune()` and `extend()`), but they may do so after `merge()`.
