### PR TITLE
Kmer comparison

### DIFF
--- a/algorithms.h
+++ b/algorithms.h
@@ -57,7 +57,7 @@ bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph
 
 struct KMerSearchParameters
 {
-  size_type seed_length;  // Parallelize based on seed kmers of this length.
+  size_type seed_length;  // Parallelize using seed kmers of this length.
   bool include_Ns;        // Include kmers containing Ns in the search.
   bool force;             // Force searching for kmers longer than the order of the index.
   std::string output;     // Base name for output.

--- a/algorithms.h
+++ b/algorithms.h
@@ -57,11 +57,11 @@ bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph
   Kmer counting. Returns the number of kmers of the given length. If k > order(),
   prints a warning and returns immediately unless force == true.
 
-  A kmer is a path of length k containing comp values 0 <= comp < sigma - 1. Alternatively,
-  the path contains either k values 0 < comp < sigma - 1, or k - 1 such values followed
-  by a 0.
+  By default, the algorithm counts only kmers consisting of bases (comp values 1-4;
+  comp values encoded in fast_bwt). If include_Ns == true, the algorithm will also
+  count kmers containing Ns (comp values encoded in sparse_bwt, except 0 and sigma - 1).
 */
-size_type countKMers(const GCSA& index, size_type k, bool force = false);
+size_type countKMers(const GCSA& index, size_type k, bool include_Ns = false, bool force = false);
 
 //------------------------------------------------------------------------------
 

--- a/algorithms.h
+++ b/algorithms.h
@@ -63,6 +63,13 @@ bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph
 */
 size_type countKMers(const GCSA& index, size_type k, bool include_Ns = false, bool force = false);
 
+/*
+  As above, but counts the kmers in two indexes and reports the results as
+  (shared kmers, kmers unique to left, kmers unique to right). The indexes must
+  use compatible alphabets.
+*/
+std::array<size_type, 3> countKMers(const GCSA& left, const GCSA& right, size_type k, bool include_Ns = false, bool force = false);
+
 //------------------------------------------------------------------------------
 
 } // namespace gcsa

--- a/algorithms.h
+++ b/algorithms.h
@@ -53,6 +53,22 @@ namespace gcsa
 bool verifyIndex(const GCSA& index, const LCPArray* lcp, std::vector<KMer>& kmers, size_type kmer_length);
 bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph);
 
+//------------------------------------------------------------------------------
+
+struct KMerSearchParameters
+{
+  size_type seed_length;  // Parallelize based on seed kmers of this length.
+  bool include_Ns;        // Include kmers containing Ns in the search.
+  bool force;             // Force searching for kmers longer than the order of the index.
+  std::string output;     // Base name for output.
+
+  const static size_type SEED_LENGTH = 5;
+  const static std::string LEFT_EXTENSION;  // .left
+  const static std::string RIGHT_EXTENSION; // .right
+
+  KMerSearchParameters() : seed_length(SEED_LENGTH), include_Ns(false), force(false), output() {}
+};
+
 /*
   Kmer counting. Returns the number of kmers of the given length. If k > order(),
   prints a warning and returns immediately unless force == true.
@@ -61,14 +77,16 @@ bool verifyIndex(const GCSA& index, const LCPArray* lcp, const InputGraph& graph
   comp values encoded in fast_bwt). If include_Ns == true, the algorithm will also
   count kmers containing Ns (comp values encoded in sparse_bwt, except 0 and sigma - 1).
 */
-size_type countKMers(const GCSA& index, size_type k, bool include_Ns = false, bool force = false);
+size_type countKMers(const GCSA& index, size_type k,
+  const KMerSearchParameters& parameters = KMerSearchParameters());
 
 /*
   As above, but counts the kmers in two indexes and reports the results as
   (shared kmers, kmers unique to left, kmers unique to right). The indexes must
   use compatible alphabets.
 */
-std::array<size_type, 3> countKMers(const GCSA& left, const GCSA& right, size_type k, bool include_Ns = false, bool force = false);
+std::array<size_type, 3> compareKMers(const GCSA& left, const GCSA& right, size_type k,
+  const KMerSearchParameters& parameters = KMerSearchParameters());
 
 //------------------------------------------------------------------------------
 

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -134,9 +134,9 @@ compareKmers(const std::string& left_name, const std::string& right_name, size_t
   double start = readTimer();
   std::array<size_type, 3> results = countKMers(left, right, k, include_Ns, force);
   double seconds = readTimer() - start;
-  std::cout << "Shared:      " << results[0] << std::endl;
-  std::cout << "Left:        " << results[1] << std::endl;
-  std::cout << "Right:       " << results[2] << std::endl;
+  std::cout << "Shared:      " << results[0] << " kmers" << std::endl;
+  std::cout << "Left:        " << results[1] << " unique kmers" << std::endl;
+  std::cout << "Right:       " << results[2] << " unique kmers" << std::endl;
   std::cout << std::endl;
 
   std::cout << "Kmers counted in " << seconds << " seconds ("

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -33,8 +33,8 @@ using namespace gcsa;
 
 const size_type DEFAULT_K = 32;
 
-void countKmers(const std::string& base_name, size_type k, bool force, bool include_Ns);
-void compareKmers(const std::string& left_name, const std::string& right_name, size_type k, bool force, bool include_Ns);
+void countKmers(const std::string& base_name, size_type k, const KMerSearchParameters& parameters);
+void compareKmers(const std::string& left_name, const std::string& right_name, size_type k, const KMerSearchParameters& parameters);
 
 //------------------------------------------------------------------------------
 
@@ -47,23 +47,32 @@ main(int argc, char** argv)
     std::cerr << "  -f    Force counting kmers longer than the order of the index" << std::endl;
     std::cerr << "  -k N  Set the length of the kmers to N (default " << DEFAULT_K << ")" << std::endl;
     std::cerr << "  -N    Include kmers containing Ns" << std::endl;
+    std::cerr << "  -o X  Output the symmetric difference to X"
+              << KMerSearchParameters::LEFT_EXTENSION << " and X"
+              << KMerSearchParameters::RIGHT_EXTENSION << std::endl;
+    std::cerr << "  -s N  Parallelize based on seed kmers of length N (default "
+              << KMerSearchParameters::SEED_LENGTH << ")" << std::endl;
     std::cerr << std::endl;
     std::exit(EXIT_SUCCESS);
   }
 
   int c = 0;
   size_type k = DEFAULT_K;
-  bool force = false, include_Ns = false;
-  while((c = getopt(argc, argv, "fk:N")) != -1)
+  KMerSearchParameters parameters;
+  while((c = getopt(argc, argv, "fk:No:s:")) != -1)
   {
     switch(c)
     {
     case 'f':
-      force = true; break;
+      parameters.force = true; break;
     case 'k':
       k = std::stoul(optarg); break;
     case 'N':
-      include_Ns = true; break;
+      parameters.include_Ns = true; break;
+    case 'o':
+      parameters.output = optarg; break;
+    case 's':
+      parameters.seed_length = std::stoul(optarg); break;
     case '?':
       std::exit(EXIT_FAILURE);
     default:
@@ -92,13 +101,14 @@ main(int argc, char** argv)
     std::cout << "Base name:   " << left_name << std::endl;
   }
   std::cout << "K:           " << k << std::endl;
-  std::cout << "Options:    ";
-  if(force) { std::cout << " force"; }
-  if(include_Ns) { std::cout << " include_Ns"; }
+  std::cout << "Options:     seed=" << parameters.seed_length;
+  if(parameters.force) { std::cout << " force"; }
+  if(parameters.include_Ns) { std::cout << " include_Ns"; }
+  if(!(parameters.output.empty())) { std::cout << " output=" << parameters.output; }
   std::cout << std::endl << std::endl;
 
-  if(compare) { compareKmers(left_name, right_name, k, force, include_Ns); }
-  else { countKmers(left_name, k, force, include_Ns); }
+  if(compare) { compareKmers(left_name, right_name, k, parameters); }
+  else { countKmers(left_name, k, parameters); }
 
   return 0;
 }
@@ -106,14 +116,14 @@ main(int argc, char** argv)
 //------------------------------------------------------------------------------
 
 void
-countKmers(const std::string& base_name, size_type k, bool force, bool include_Ns)
+countKmers(const std::string& base_name, size_type k, const KMerSearchParameters& parameters)
 {
   GCSA index;
   sdsl::load_from_file(index, base_name + GCSA::EXTENSION);
   std::cout << "GCSA:        " << index.size() << " paths, order " << index.order() << std::endl;
 
   double start = readTimer();
-  size_type kmer_count = countKMers(index, k, include_Ns, force);
+  size_type kmer_count = countKMers(index, k, parameters);
   double seconds = readTimer() - start;
   std::cout << "Kmers:       " << kmer_count << std::endl;
   std::cout << std::endl;
@@ -123,7 +133,7 @@ countKmers(const std::string& base_name, size_type k, bool force, bool include_N
 }
 
 void
-compareKmers(const std::string& left_name, const std::string& right_name, size_type k, bool force, bool include_Ns)
+compareKmers(const std::string& left_name, const std::string& right_name, size_type k, const KMerSearchParameters& parameters)
 {
   GCSA left, right;
   sdsl::load_from_file(left, left_name + GCSA::EXTENSION);
@@ -132,7 +142,7 @@ compareKmers(const std::string& left_name, const std::string& right_name, size_t
   std::cout << "Right:       " << right.size() << " paths, order " << right.order() << std::endl;
 
   double start = readTimer();
-  std::array<size_type, 3> results = countKMers(left, right, k, include_Ns, force);
+  std::array<size_type, 3> results = compareKMers(left, right, k, parameters);
   double seconds = readTimer() - start;
   std::cout << "Shared:      " << results[0] << " kmers" << std::endl;
   std::cout << "Left:        " << results[1] << " unique kmers" << std::endl;

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -50,7 +50,7 @@ main(int argc, char** argv)
     std::cerr << "  -o X  Output the symmetric difference to X"
               << KMerSearchParameters::LEFT_EXTENSION << " and X"
               << KMerSearchParameters::RIGHT_EXTENSION << std::endl;
-    std::cerr << "  -s N  Parallelize based on seed kmers of length N (default "
+    std::cerr << "  -s N  Parallelize using seed kmers of length N (default "
               << KMerSearchParameters::SEED_LENGTH << ")" << std::endl;
     std::cerr << std::endl;
     std::exit(EXIT_SUCCESS);

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -31,26 +31,37 @@ using namespace gcsa;
 
 //------------------------------------------------------------------------------
 
+const size_type DEFAULT_K = 32;
+
+void countKmers(const std::string& base_name, size_type k, bool force, bool include_Ns);
+void compareKmers(const std::string& left_name, const std::string& right_name, size_type k, bool force, bool include_Ns);
+
+//------------------------------------------------------------------------------
+
 int
 main(int argc, char** argv)
 {
-  if(argc < 3)
+  if(argc < 2)
   {
-    std::cerr << "usage: count_kmers [options] base_name k" << std::endl;
-    std::cerr << "  -f  Force counting kmers longer than the order of the index" << std::endl;
-    std::cerr << "  -N  Include kmers containing Ns" << std::endl;
+    std::cerr << "usage: count_kmers [options] base_name [base_name2]" << std::endl;
+    std::cerr << "  -f    Force counting kmers longer than the order of the index" << std::endl;
+    std::cerr << "  -k N  Set the length of the kmers to N (default " << DEFAULT_K << ")" << std::endl;
+    std::cerr << "  -N    Include kmers containing Ns" << std::endl;
     std::cerr << std::endl;
     std::exit(EXIT_SUCCESS);
   }
 
   int c = 0;
+  size_type k = DEFAULT_K;
   bool force = false, include_Ns = false;
-  while((c = getopt(argc, argv, "fN")) != -1)
+  while((c = getopt(argc, argv, "fk:N")) != -1)
   {
     switch(c)
     {
     case 'f':
       force = true; break;
+    case 'k':
+      k = std::stoul(optarg); break;
     case 'N':
       include_Ns = true; break;
     case '?':
@@ -60,39 +71,77 @@ main(int argc, char** argv)
     }
   }
 
-  if(optind + 1 >= argc)
+  if(optind >= argc)
   {
-    std::cerr << "count_kmers: Base name or kmer length not specified" << std::endl;
+    std::cerr << "count_kmers: Base name not specified" << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  std::string base_name = argv[optind];
-  size_type k = std::stoul(argv[optind + 1]);
-
+  bool compare = (optind + 1 < argc);
+  std::string left_name = argv[optind];
+  std::string right_name = (compare ? argv[optind + 1] : "");
 
   std::cout << "Kmer counter" << std::endl;
   std::cout << std::endl;
-  std::cout << "Base name:  " << base_name << std::endl;
-  std::cout << "K:          " << k << std::endl;
-  std::cout << "Options:   ";
+  if(compare)
+  {
+    std::cout << "Left name:   " << left_name << std::endl;
+    std::cout << "Right name:  " << right_name << std::endl;
+  }
+  else
+  {
+    std::cout << "Base name:   " << left_name << std::endl;
+  }
+  std::cout << "K:           " << k << std::endl;
+  std::cout << "Options:    ";
   if(force) { std::cout << " force"; }
   if(include_Ns) { std::cout << " include_Ns"; }
   std::cout << std::endl << std::endl;
 
+  if(compare) { compareKmers(left_name, right_name, k, force, include_Ns); }
+  else { countKmers(left_name, k, force, include_Ns); }
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void
+countKmers(const std::string& base_name, size_type k, bool force, bool include_Ns)
+{
   GCSA index;
-  std::string gcsa_name = base_name + GCSA::EXTENSION;
-  sdsl::load_from_file(index, gcsa_name);
-  std::cout << "GCSA:       " << index.size() << " paths, order " << index.order() << std::endl;
+  sdsl::load_from_file(index, base_name + GCSA::EXTENSION);
+  std::cout << "GCSA:        " << index.size() << " paths, order " << index.order() << std::endl;
 
   double start = readTimer();
   size_type kmer_count = countKMers(index, k, include_Ns, force);
   double seconds = readTimer() - start;
-  std::cout << "Kmers:      " << kmer_count << std::endl;
+  std::cout << "Kmers:       " << kmer_count << std::endl;
   std::cout << std::endl;
 
   std::cout << "Kmers counted in " << seconds << " seconds (" << (kmer_count / seconds) << " / s)" << std::endl;
   std::cout << std::endl;
+}
 
-  return 0;
+void
+compareKmers(const std::string& left_name, const std::string& right_name, size_type k, bool force, bool include_Ns)
+{
+  GCSA left, right;
+  sdsl::load_from_file(left, left_name + GCSA::EXTENSION);
+  std::cout << "Left:        " << left.size() << " paths, order " << left.order() << std::endl;
+  sdsl::load_from_file(right, right_name + GCSA::EXTENSION);
+  std::cout << "Right:       " << right.size() << " paths, order " << right.order() << std::endl;
+
+  double start = readTimer();
+  std::array<size_type, 3> results = countKMers(left, right, k, include_Ns, force);
+  double seconds = readTimer() - start;
+  std::cout << "Shared:      " << results[0] << std::endl;
+  std::cout << "Left:        " << results[1] << std::endl;
+  std::cout << "Right:       " << results[2] << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "Kmers counted in " << seconds << " seconds ("
+            << ((results[0] + results[1] + results[2]) / seconds) << " / s)" << std::endl;
+  std::cout << std::endl;
 }
 
 //------------------------------------------------------------------------------

--- a/count_kmers.cpp
+++ b/count_kmers.cpp
@@ -23,6 +23,7 @@
 */
 
 #include <string>
+#include <unistd.h>
 
 #include "algorithms.h"
 
@@ -35,18 +36,47 @@ main(int argc, char** argv)
 {
   if(argc < 3)
   {
-    std::cerr << "usage: count_kmers base_name k" << std::endl;
+    std::cerr << "usage: count_kmers [options] base_name k" << std::endl;
+    std::cerr << "  -f  Force counting kmers longer than the order of the index" << std::endl;
+    std::cerr << "  -N  Include kmers containing Ns" << std::endl;
     std::cerr << std::endl;
     std::exit(EXIT_SUCCESS);
   }
 
-  std::string base_name = argv[1];
-  size_type k = std::stoul(argv[2]);
+  int c = 0;
+  bool force = false, include_Ns = false;
+  while((c = getopt(argc, argv, "fN")) != -1)
+  {
+    switch(c)
+    {
+    case 'f':
+      force = true; break;
+    case 'N':
+      include_Ns = true; break;
+    case '?':
+      std::exit(EXIT_FAILURE);
+    default:
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  if(optind + 1 >= argc)
+  {
+    std::cerr << "count_kmers: Base name or kmer length not specified" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  std::string base_name = argv[optind];
+  size_type k = std::stoul(argv[optind + 1]);
+
+
   std::cout << "Kmer counter" << std::endl;
   std::cout << std::endl;
   std::cout << "Base name:  " << base_name << std::endl;
   std::cout << "K:          " << k << std::endl;
-  std::cout << std::endl;
+  std::cout << "Options:   ";
+  if(force) { std::cout << " force"; }
+  if(include_Ns) { std::cout << " include_Ns"; }
+  std::cout << std::endl << std::endl;
 
   GCSA index;
   std::string gcsa_name = base_name + GCSA::EXTENSION;
@@ -54,7 +84,7 @@ main(int argc, char** argv)
   std::cout << "GCSA:       " << index.size() << " paths, order " << index.order() << std::endl;
 
   double start = readTimer();
-  size_type kmer_count = countKMers(index, k);
+  size_type kmer_count = countKMers(index, k, include_Ns, force);
   double seconds = readTimer() - start;
   std::cout << "Kmers:      " << kmer_count << std::endl;
   std::cout << std::endl;

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -723,6 +723,9 @@ GCSA::initSupport()
 void
 GCSA::LF_fast(range_type range, std::vector<range_type>& results) const
 {
+  for(size_type comp = 1; comp <= this->alpha.fast_chars; comp++) { results[comp] = Range::empty_range(); }
+  if(Range::empty(range)) { return; }
+
   if(range.first == range.second) // Single path node.
   {
     for(size_type comp = 1; comp <= this->alpha.fast_chars; comp++)
@@ -731,7 +734,6 @@ GCSA::LF_fast(range_type range, std::vector<range_type>& results) const
       {
         results[comp].first = results[comp].second = this->edge_rank(this->LF(this->fast_rank, range.first, comp));
       }
-      else { results[comp] = Range::empty_range(); }
     }
   }
   else  // General case.
@@ -747,6 +749,9 @@ GCSA::LF_fast(range_type range, std::vector<range_type>& results) const
 void
 GCSA::LF_all(range_type range, std::vector<range_type>& results) const
 {
+  for(size_type comp = 1; comp + 1 < this->alpha.sigma; comp++) { results[comp] = Range::empty_range(); }
+  if(Range::empty(range)) { return; }
+
   if(range.first == range.second) // Single path node.
   {
     for(size_type comp = 1; comp <= this->alpha.fast_chars; comp++)
@@ -755,7 +760,6 @@ GCSA::LF_all(range_type range, std::vector<range_type>& results) const
       {
         results[comp].first = results[comp].second = this->edge_rank(this->LF(this->fast_rank, range.first, comp));
       }
-      else { results[comp] = Range::empty_range(); }
     }
     for(size_type comp = this->alpha.fast_chars + 1; comp + 1 < this->alpha.sigma; comp++)
     {
@@ -763,7 +767,6 @@ GCSA::LF_all(range_type range, std::vector<range_type>& results) const
       {
         results[comp].first = results[comp].second = this->edge_rank(this->LF(this->sparse_rank, range.first, comp));
       }
-      else { results[comp] = Range::empty_range(); }
     }
   }
   else  // General case.

--- a/gcsa.cpp
+++ b/gcsa.cpp
@@ -720,28 +720,32 @@ GCSA::initSupport()
 
 //------------------------------------------------------------------------------
 
-bool
-GCSA::verifyIndex(std::vector<KMer>& kmers, size_type kmer_length) const
+void
+GCSA::LF_fast(range_type range, std::vector<range_type>& results) const
 {
-  return gcsa::verifyIndex(*this, 0, kmers, kmer_length);
+  if(range.first == range.second) // Single path node.
+  {
+    for(size_type comp = 1; comp <= this->alpha.fast_chars; comp++)
+    {
+      if(this->fast_bwt[comp][range.first])
+      {
+        results[comp].first = results[comp].second = this->edge_rank(this->LF(this->fast_rank, range.first, comp));
+      }
+      else { results[comp] = Range::empty_range(); }
+    }
+  }
+  else  // General case.
+  {
+    for(size_type comp = 1; comp <= this->alpha.fast_chars; comp++)
+    {
+      results[comp] = this->LF(this->fast_rank, range, comp);
+      if(!Range::empty(results[comp])) { results[comp] = this->pathNodeRange(results[comp]); }
+    }
+  }
 }
-
-bool
-GCSA::verifyIndex(const InputGraph& graph) const
-{
-  return gcsa::verifyIndex(*this, 0, graph);
-}
-
-size_type
-GCSA::countKMers(size_type k, bool force) const
-{
-  return gcsa::countKMers(*this, k, force);
-}
-
-//------------------------------------------------------------------------------
 
 void
-GCSA::LF(range_type range, std::vector<range_type>& results) const
+GCSA::LF_all(range_type range, std::vector<range_type>& results) const
 {
   if(range.first == range.second) // Single path node.
   {

--- a/gcsa.h
+++ b/gcsa.h
@@ -74,13 +74,8 @@ public:
 //------------------------------------------------------------------------------
 
   /*
-    Algorithms using GCSA. See algorithms.h for more information.
+    Algorithms using GCSA. These have been moved to algorithms.h.
   */
-
-  bool verifyIndex(std::vector<KMer>& kmers, size_type kmer_length) const;
-  bool verifyIndex(const InputGraph& graph) const;
-
-  size_type countKMers(size_type k, bool force = false) const;
 
 //------------------------------------------------------------------------------
 
@@ -186,9 +181,11 @@ public:
     return this->edge_rank(this->LF(this->sparse_rank, path_node, 0));
   }
 
-  // LF(range, c) for 1 <= c < sigma - 1.
-  // FIXME optimize this
-  void LF(range_type range, std::vector<range_type>& results) const;
+  // LF(range, comp) for fast comp values.
+  void LF_fast(range_type range, std::vector<range_type>& results) const;
+
+  // LF(range, comp) for 1 <= comp < sigma - 1.
+  void LF_all(range_type range, std::vector<range_type>& results) const;
 
   inline bool sampled(size_type path_node) const { return this->sampled_paths[path_node]; }
 


### PR DESCRIPTION
Compare two indexes based on the kmers they contain (for `k <= 64`). Determine the number of shared kmers and kmers unique to one of the indexes. Optionally output the kmers in the symmetric difference.

32-mer comparison of two whole-genome human indexes takes a few hours on a 32-core server.
