### PR TITLE
Visible temp files

### DIFF
--- a/include/gcsa/internal.h
+++ b/include/gcsa/internal.h
@@ -28,7 +28,6 @@
 #include <map>
 
 // C++ threads for DiskIO, ReadBuffer.
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>

--- a/include/gcsa/path_graph.h
+++ b/include/gcsa/path_graph.h
@@ -300,7 +300,7 @@ struct PathGraph
   size_type unique, redundant, unsorted, nondeterministic;
 
   const static size_type UNKNOWN = ~(size_type)0;
-  const static std::string PREFIX;  // .gcsa
+  const static std::string PREFIX;  // gcsa
 
   PathGraph(const InputGraph& source, sdsl::sd_vector<>& key_exists);
   PathGraph(size_type file_count, size_type path_order, size_type steps);
@@ -352,7 +352,7 @@ struct MergedGraph
   std::vector<size_type> next_from; // Where to find the corresponding additional from nodes.
 
   const static size_type UNKNOWN = ~(size_type)0;
-  const static std::string PREFIX;  // .gcsa
+  const static std::string PREFIX;  // gcsa
 
   MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, const LCP& kmer_lcp, size_type size_limit);
   ~MergedGraph();

--- a/include/gcsa/utils.h
+++ b/include/gcsa/utils.h
@@ -34,7 +34,8 @@
 
 #include <sdsl/wavelet_trees.hpp>
 
-// FIXME Later: Use named critical sections.
+// FIXME Later: Get rid of OpenMP.
+#include <atomic>
 #include <omp.h>
 
 namespace gcsa
@@ -217,8 +218,9 @@ size_type writeVolume();  // Only for GCSA construction.
 
 struct TempFile
 {
-  static std::string temp_dir;
-  const static std::string DEFAULT_TEMP_DIR;
+  static std::atomic<size_type> counter;
+  static std::string            temp_dir;
+  const static std::string      DEFAULT_TEMP_DIR;
 
   static void setDirectory(const std::string& directory);
   static std::string getName(const std::string& name_part);

--- a/path_graph.cpp
+++ b/path_graph.cpp
@@ -659,7 +659,7 @@ PathRange::PathRange(size_type start, size_type stop, range_type _left_lcp, Path
 
 //------------------------------------------------------------------------------
 
-const std::string PathGraph::PREFIX = ".gcsa";
+const std::string PathGraph::PREFIX = "gcsa";
 
 PathGraph::PathGraph(const InputGraph& source, sdsl::sd_vector<>& key_exists)
 {
@@ -984,7 +984,7 @@ PathGraph::read(std::vector<PathNode>& paths, std::vector<PathNode::rank_type>& 
 
 //------------------------------------------------------------------------------
 
-const std::string MergedGraph::PREFIX = ".gcsa";
+const std::string MergedGraph::PREFIX = "gcsa";
 
 struct SameFromSet
 {

--- a/utils.cpp
+++ b/utils.cpp
@@ -112,6 +112,8 @@ writeVolume()
 
 //------------------------------------------------------------------------------
 
+std::atomic<size_type> TempFile::counter(0);
+
 const std::string TempFile::DEFAULT_TEMP_DIR = ".";
 std::string TempFile::temp_dir = TempFile::DEFAULT_TEMP_DIR;
 
@@ -132,7 +134,7 @@ TempFile::getName(const std::string& name_part)
   return temp_dir + '/' + name_part + '_'
     + std::string(hostname) + '_'
     + sdsl::util::to_string(sdsl::util::pid()) + '_'
-    + sdsl::util::to_string(sdsl::util::id());
+    + sdsl::util::to_string(counter++);
 }
 
 void


### PR DESCRIPTION
The naming scheme for temporary files is now `gcsa_host_process_counter` instead of `.gcsa_host_process_counter`.