### PR TITLE
Add a special exit code for exceeding size limit

### DIFF
--- a/include/gcsa/utils.h
+++ b/include/gcsa/utils.h
@@ -71,7 +71,7 @@ constexpr double MEGABYTE_DOUBLE = KILOBYTE_DOUBLE * KILOBYTE_DOUBLE;
 constexpr double GIGABYTE_DOUBLE = KILOBYTE_DOUBLE * MEGABYTE_DOUBLE;
 
 // Exit code for exceeding parameter-defined size limit.
-constexpr size_type EXIT_SIZE_LIMIT_EXCEEDED = 0x2BAD512E;
+constexpr int EXIT_SIZE_LIMIT_EXCEEDED = 0x2BAD512E;
 
 //------------------------------------------------------------------------------
 

--- a/include/gcsa/utils.h
+++ b/include/gcsa/utils.h
@@ -70,6 +70,9 @@ constexpr double MILLION_DOUBLE  = 1000000.0;
 constexpr double MEGABYTE_DOUBLE = KILOBYTE_DOUBLE * KILOBYTE_DOUBLE;
 constexpr double GIGABYTE_DOUBLE = KILOBYTE_DOUBLE * MEGABYTE_DOUBLE;
 
+// Exit code for exceeding parameter-defined size limit.
+constexpr size_type EXIT_SIZE_LIMIT_EXCEEDED = 0x2BAD512E;
+
 //------------------------------------------------------------------------------
 
 /*

--- a/src/gcsa.cpp
+++ b/src/gcsa.cpp
@@ -452,7 +452,7 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters) :
   {
     std::cerr << "GCSA::GCSA(): The input is too large: " << (bytes_required / GIGABYTE_DOUBLE) << " GB" << std::endl;
     std::cerr << "GCSA::GCSA(): Construction aborted" << std::endl;
-    std::exit(EXIT_FAILURE);
+    std::exit(EXIT_SIZE_LIMIT_EXCEEDED);
   }
 
   // Extract the keys and build the necessary support structures.

--- a/src/path_graph.cpp
+++ b/src/path_graph.cpp
@@ -364,7 +364,7 @@ PathGraphBuilder::write(PriorityNode& path)
   if(this->graph.bytes() + path.bytes() > this->limit)
   {
     std::cerr << "PathGraphBuilder::write(): Size limit exceeded, construction aborted" << std::endl;
-    std::exit(EXIT_FAILURE);
+    std::exit(EXIT_SIZE_LIMIT_EXCEEDED);
   }
   writePath(path.node, path.label, this->path_files[path.file], this->rank_files[path.file]);
 
@@ -382,7 +382,7 @@ PathGraphBuilder::write(std::vector<PathNode>& paths, std::vector<PathNode::rank
     if(bytes_required + this->graph.bytes() > this->limit)
     {
       std::cerr << "PathGraphBuilder::write(): Size limit exceeded, construction aborted" << std::endl;
-      std::exit(EXIT_FAILURE);
+      std::exit(EXIT_SIZE_LIMIT_EXCEEDED);
     }
     for(size_type i = 0; i < paths.size(); i++)
     {
@@ -1185,7 +1185,7 @@ MergedGraph::MergedGraph(const PathGraph& source, const DeBruijnGraph& mapper, c
     if(bytes > size_limit)
     {
       std::cerr << "MergedGraph::MergedGraph(): Size limit exceeded, construction aborted" << std::endl;
-      std::exit(EXIT_FAILURE);
+      std::exit(EXIT_SIZE_LIMIT_EXCEEDED);
     }
     writePath(curr.node, curr.label, path_file, rank_file);
     for(size_type i = 1; i < same_from_set.nodes.size(); i++)


### PR DESCRIPTION
The current forking logic in VG is limited by the fact that it can't distinguish exit failures from insufficient pruning from other failures (recently indicated by [this issue](https://github.com/vgteam/vg/issues/4035)). This PR adds a special exit code for hitting the size limit.