### PR TITLE
Add a memory limit for KMers, PathNodes and ranks

### DIFF
--- a/include/gcsa/files.h
+++ b/include/gcsa/files.h
@@ -84,8 +84,8 @@ struct InputGraph
   const static std::string BINARY_EXTENSION;  // .graph
   const static std::string TEXT_EXTENSION;    // .gcsa2
 
-  InputGraph(const std::vector<std::string>& files, bool binary_format, const Alphabet& alphabet = Alphabet(), const std::string& mapping_name = "");
-  InputGraph(size_type file_count, char** base_names, bool binary_format, const Alphabet& alphabet = Alphabet(), const std::string& mapping_name = "");
+  InputGraph(const std::vector<std::string>& files, bool binary_format, const ConstructionParameters& parameters, const Alphabet& alphabet = Alphabet(), const std::string& mapping_name = "");
+  InputGraph(size_type file_count, char** base_names, bool binary_format, const ConstructionParameters& parameters, const Alphabet& alphabet = Alphabet(), const std::string& mapping_name = "");
   ~InputGraph();
 
   void open(std::ifstream& input, size_type file) const;
@@ -113,7 +113,7 @@ struct InputGraph
   InputGraph& operator= (const InputGraph&) = delete;
 
 private:
-  void build(const std::string& mapping_name);
+  void build(const ConstructionParameters& parameters, const std::string& mapping_name);
 };
 
 //------------------------------------------------------------------------------

--- a/include/gcsa/path_graph.h
+++ b/include/gcsa/path_graph.h
@@ -334,7 +334,7 @@ struct PathGraph
       path_graph.prune(lcp, total_size_limit - path_graph.bytes())
   */
   void prune(const LCP& lcp, size_type size_limit);
-  void extend(size_type size_limit);
+  void extend(size_type size_limit, size_type memory_limit);
 
   void debugExtend();
 

--- a/include/gcsa/support.h
+++ b/include/gcsa/support.h
@@ -46,28 +46,35 @@ namespace gcsa
 
 struct ConstructionParameters
 {
-  constexpr static size_type DOUBLING_STEPS = 4;
-  constexpr static size_type MAX_STEPS      = 4;
-  constexpr static size_type SIZE_LIMIT     = 2048;   // Gigabytes.
-  constexpr static size_type ABSOLUTE_LIMIT = 16384;  // Gigabytes.
-  constexpr static size_type SAMPLE_PERIOD  = 64;
-  constexpr static size_type LCP_BRANCHING  = 64;
+  constexpr static size_type DOUBLING_STEPS        = 4;
+  constexpr static size_type MAX_STEPS             = 4;
+  constexpr static size_type SIZE_LIMIT            = 2048;   // Gigabytes.
+  constexpr static size_type ABSOLUTE_LIMIT        = 16384;  // Gigabytes.
+  constexpr static size_type MEMORY_LIMIT          = 1024;   // Gigabytes.
+  constexpr static size_type ABSOLUTE_MEMORY_LIMIT = 8192;   // Gigabytes.
+  constexpr static size_type SAMPLE_PERIOD         = 64;
+  constexpr static size_type LCP_BRANCHING         = 64;
+  
 
   ConstructionParameters();
   void setSteps(size_type steps);
   void setLimit(size_type gigabytes);
   void setLimitBytes(size_type bytes);
   void reduceLimit(size_type bytes);
+  void setMemoryLimit(size_type gigabytes);
+  void setMemoryLimitBytes(size_type bytes);
   void setSamplePeriod(size_type period);
   void setLCPBranching(size_type factor);
 
   size_type getSteps() const { return this->doubling_steps; }
   size_type getLimitBytes() const { return this->size_limit; }
+  size_type getMemoryLimitBytes() const { return this->memory_limit; }
   size_type getSamplePeriod() const { return this->sample_period; }
   size_type getLCPBranching() const { return this->lcp_branching; }
 
   size_type doubling_steps;
   size_type size_limit;
+  size_type memory_limit;
   size_type sample_period;
   size_type lcp_branching;
 };

--- a/src/build_gcsa.cpp
+++ b/src/build_gcsa.cpp
@@ -140,7 +140,7 @@ main(int argc, char** argv)
   }
   std::cout << std::endl;
 
-  InputGraph graph(argc - optind, argv + optind, binary, Alphabet(), mapping_file);
+  InputGraph graph(argc - optind, argv + optind, binary, parameters, Alphabet(), mapping_file);
 
   GCSA index;
   LCPArray lcp;

--- a/src/convert_graph.cpp
+++ b/src/convert_graph.cpp
@@ -41,7 +41,8 @@ main(int argc, char** argv)
   else
   {
     Version::print(std::cout, "GCSA2 input graph converter");
-    InputGraph graph(argc - 1, argv + 1, false);
+    ConstructionParameters parameters;
+    InputGraph graph(argc - 1, argv + 1, false, parameters);
     for(size_type i = 0; i < graph.files(); i++)
     {
       std::string base_name = argv[i + 1];

--- a/src/gcsa.cpp
+++ b/src/gcsa.cpp
@@ -502,7 +502,7 @@ GCSA::GCSA(InputGraph& graph, const ConstructionParameters& parameters) :
                 << (2 * path_graph.k()) << ")" << std::endl;
     }
     path_graph.prune(lcp, parameters.getLimitBytes() - path_graph.bytes());
-    path_graph.extend(parameters.getLimitBytes() - path_graph.bytes());
+    path_graph.extend(parameters.getLimitBytes() - path_graph.bytes(), parameters.getMemoryLimitBytes());
   }
   if(Verbosity::level >= Verbosity::EXTENDED)
   {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -37,6 +37,7 @@ constexpr size_type ConstructionParameters::DOUBLING_STEPS;
 constexpr size_type ConstructionParameters::MAX_STEPS;
 constexpr size_type ConstructionParameters::SIZE_LIMIT;
 constexpr size_type ConstructionParameters::ABSOLUTE_LIMIT;
+constexpr size_type ConstructionParameters::MEMORY_LIMIT;
 constexpr size_type ConstructionParameters::SAMPLE_PERIOD;
 constexpr size_type ConstructionParameters::LCP_BRANCHING;
 
@@ -93,7 +94,8 @@ const sdsl::int_vector<8> Alphabet::DEFAULT_COMP2CHAR = { '$', 'A', 'C', 'G', 'T
 
 ConstructionParameters::ConstructionParameters() :
   doubling_steps(DOUBLING_STEPS), size_limit(SIZE_LIMIT * GIGABYTE),
-  sample_period(SAMPLE_PERIOD), lcp_branching(LCP_BRANCHING)
+  memory_limit(MEMORY_LIMIT * GIGABYTE), sample_period(SAMPLE_PERIOD),
+  lcp_branching(LCP_BRANCHING)
 {
 }
 
@@ -120,6 +122,18 @@ ConstructionParameters::reduceLimit(size_type bytes)
 {
   if(bytes > this->size_limit) { this->size_limit = 0; }
   else { this->size_limit -= bytes; }
+}
+
+void
+ConstructionParameters::setMemoryLimit(size_type gigabytes)
+{
+  this->memory_limit = Range::bound(gigabytes, 1, ABSOLUTE_MEMORY_LIMIT) * GIGABYTE;
+}
+
+void
+ConstructionParameters::setMemoryLimitBytes(size_type bytes)
+{
+  this->memory_limit = Range::bound(bytes, 1, ABSOLUTE_MEMORY_LIMIT * GIGABYTE);
 }
 
 void

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -38,6 +38,7 @@ constexpr size_type ConstructionParameters::MAX_STEPS;
 constexpr size_type ConstructionParameters::SIZE_LIMIT;
 constexpr size_type ConstructionParameters::ABSOLUTE_LIMIT;
 constexpr size_type ConstructionParameters::MEMORY_LIMIT;
+constexpr size_type ConstructionParameters::ABSOLUTE_MEMORY_LIMIT;
 constexpr size_type ConstructionParameters::SAMPLE_PERIOD;
 constexpr size_type ConstructionParameters::LCP_BRANCHING;
 


### PR DESCRIPTION
This PR adds a parameter for a memory limit to the `ConstructionParameters`. It applies only to the largest memory-utilizing components: the `KMer`, `PathNode`, and `PathNode::rank_type` vectors. If any of the respective files would need to exceed the memory limit to be loaded into memory, it now triggers an error and exits.